### PR TITLE
always defer interaction

### DIFF
--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -25,6 +25,8 @@ export class License extends BaseCommand implements ICommand {
     }
 
     public async handle(): Promise<void> {
+        await this.interaction.deferReply();
+
         const input = this.getArgument<string>('kenteken');
         if (!input) {
             return;
@@ -33,12 +35,12 @@ export class License extends BaseCommand implements ICommand {
         const license = input.toUpperCase().split('-').join('');
 
         if (LicenseUtil.isNorwegian(license)) {
-            this.getNorwegianInfo(license);
+            await this.getNorwegianInfo(license);
             return;
         }
 
         if (!LicenseUtil.isValid(license)) {
-            this.reply('Dat is geen kenteken kut');
+            await this.interaction.followUp('Dat is geen kenteken kut');
             return;
         }
 
@@ -89,7 +91,7 @@ export class License extends BaseCommand implements ICommand {
                 .setURL(`https://finnik.nl/kenteken/${license}/gratis`)
         );
 
-        this.reply({ embeds: [response], components: [links] });
+        await this.interaction.followUp({ embeds: [response], components: [links] });
 
         this.insertSighting(license);
     }
@@ -150,6 +152,6 @@ export class License extends BaseCommand implements ICommand {
             .setThumbnail(`https://www.kentekencheck.nl/assets/img/brands/${Str.humanToSnakeCase(brand)}.png`)
             .setFooter({ text: `🇳🇴 ${license}` });
 
-        this.reply({ embeds: [response] });
+        await this.interaction.followUp({ embeds: [response] });
     }
 }


### PR DESCRIPTION
Always defer an interaction and respond with a followup. This fixes a crash in case the bot takes over 3 seconds to reply