### PR TITLE
fix(deps): bump glob to 10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7087,9 +7087,10 @@
       }
     },
     "node_modules/js-beautify/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",


### PR DESCRIPTION
## Summary
- Bumps transitive `glob@10.4.5` (via `sequelize-cli` → `js-beautify`) to `10.5.0`, within the existing `^10.4.2` range.
- Closes dependabot alert [#74](https://github.com/KentekenBot/KentekenBot/security/dependabot/74) (GHSA-5j98-mcp5-4vw2, high).

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (65/65 pass)
- [x] `npm audit` — runtime high removed; remaining 6 are dev-only (nodemon/jest transitive)

Lockfile-only change, no manifest edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)