### PR TITLE
feat: add /randomspot command to resurface past spots

### DIFF
--- a/src/commands/randomspot.ts
+++ b/src/commands/randomspot.ts
@@ -1,6 +1,6 @@
 import { ICommand } from '../interfaces/command';
 import { BaseCommand } from './base-command';
-import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType } from 'discord.js';
+import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType, MessageFlags } from 'discord.js';
 import { RandomSpots } from '../queries/random-spot';
 import { RandomSpotView } from '../util/random-spot-view';
 
@@ -30,10 +30,11 @@ export class RandomSpot extends BaseCommand implements ICommand {
             return;
         }
 
-        const embed = RandomSpotView.build(spot);
+        const components = RandomSpotView.build(spot);
 
         await this.interaction.followUp({
-            embeds: [embed],
+            components,
+            flags: MessageFlags.IsComponentsV2,
             allowedMentions: { users: [] },
         });
     }

--- a/src/commands/randomspot.ts
+++ b/src/commands/randomspot.ts
@@ -1,0 +1,40 @@
+import { ICommand } from '../interfaces/command';
+import { BaseCommand } from './base-command';
+import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType } from 'discord.js';
+import { RandomSpots } from '../queries/random-spot';
+import { RandomSpotView } from '../util/random-spot-view';
+
+export class RandomSpot extends BaseCommand implements ICommand {
+    public register(builder: SlashCommandBuilder): SlashCommandBuilder {
+        return builder
+            .setName('randomspot')
+            .setContexts(
+                InteractionContextType.Guild,
+                InteractionContextType.BotDM,
+                InteractionContextType.PrivateChannel
+            )
+            .setIntegrationTypes(ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall)
+            .setDescription('Haal een willekeurige eerdere spot op');
+    }
+
+    public async handle(): Promise<void> {
+        await this.interaction.deferReply();
+
+        const guildId = this.interaction.guildId;
+        const userId = guildId ? null : this.interaction.user.id;
+
+        const spot = await RandomSpots.get(guildId, userId);
+
+        if (!spot) {
+            await this.interaction.followUp('Er zijn nog geen spots om op te halen.');
+            return;
+        }
+
+        const embed = RandomSpotView.build(spot);
+
+        await this.interaction.followUp({
+            embeds: [embed],
+            allowedMentions: { users: [] },
+        });
+    }
+}

--- a/src/queries/random-spot.ts
+++ b/src/queries/random-spot.ts
@@ -1,0 +1,55 @@
+import { literal } from 'sequelize';
+import { Sighting } from '../models/sighting';
+import { Vehicle } from '../models/vehicle';
+import { RandomSpot } from '../types/random-spot';
+
+export class RandomSpots {
+    public static async get(discordGuildId: string | null, discordUserId: string | null): Promise<RandomSpot | null> {
+        const where: Record<string, string> = {};
+
+        if (discordGuildId) {
+            where.discordGuildId = discordGuildId;
+        }
+
+        if (discordUserId) {
+            where.discordUserId = discordUserId;
+        }
+
+        const sighting = await Sighting.findOne({
+            where,
+            order: literal('RANDOM()'),
+            include: [
+                {
+                    model: Vehicle,
+                    as: 'vehicle',
+                    required: false,
+                },
+            ],
+        });
+
+        if (!sighting) {
+            return null;
+        }
+
+        const vehicle = sighting.vehicle;
+
+        return {
+            license: sighting.license,
+            comment: sighting.comment,
+            createdAt: sighting.createdAt,
+            discordUserId: sighting.discordUserId,
+            discordGuildId: sighting.discordGuildId,
+            discordChannelId: sighting.discordChannelId,
+            discordInteractionId: sighting.discordInteractionId,
+            vehicle: vehicle
+                ? {
+                      brand: vehicle.brand,
+                      tradeName: vehicle.tradeName,
+                      color: vehicle.color,
+                      totalHorsepower: vehicle.totalHorsepower,
+                      primaryFuelType: vehicle.primaryFuelType,
+                  }
+                : null,
+        };
+    }
+}

--- a/src/services/command-collection.ts
+++ b/src/services/command-collection.ts
@@ -7,6 +7,7 @@ import { Ping } from '../commands/ping';
 import { Status } from '../commands/status';
 import { UserSpots } from '../commands/userspots';
 import { ServerSpots } from '../commands/serverspots';
+import { RandomSpot } from '../commands/randomspot';
 
 export class CommandCollection {
     private static instance: CommandCollection;
@@ -17,7 +18,7 @@ export class CommandCollection {
     }
 
     private getCommandClasses(): CommandConstructor[] {
-        return [License, Ping, Status, UserSpots, ServerSpots];
+        return [License, Ping, Status, UserSpots, ServerSpots, RandomSpot];
     }
 
     private getCommands(): { builder: SlashCommandBuilder; command: CommandConstructor }[] {

--- a/src/types/random-spot.ts
+++ b/src/types/random-spot.ts
@@ -1,0 +1,16 @@
+export interface RandomSpot {
+    license: string;
+    comment: string | null;
+    createdAt: Date;
+    discordUserId: string;
+    discordGuildId: string;
+    discordChannelId: string;
+    discordInteractionId: string;
+    vehicle: {
+        brand: string | null;
+        tradeName: string | null;
+        color: string | null;
+        totalHorsepower: string | null;
+        primaryFuelType: string | null;
+    } | null;
+}

--- a/src/util/random-spot-view.ts
+++ b/src/util/random-spot-view.ts
@@ -1,0 +1,50 @@
+import { EmbedBuilder } from 'discord.js';
+import { RandomSpot } from '../types/random-spot';
+import { Str } from './str';
+import { License } from './license';
+import { DateTime } from './date-time';
+import { DiscordTimestamps } from '../enums/discord-timestamps';
+
+export class RandomSpotView {
+    public static build(spot: RandomSpot): EmbedBuilder {
+        const embed = new EmbedBuilder().setColor(0x5865f2).setTitle('🎲 Random spot');
+
+        const vehicle = spot.vehicle;
+        const formattedLicense = License.format(spot.license) || spot.license;
+
+        if (vehicle?.brand && vehicle?.tradeName) {
+            const name = `${Str.toTitleCase(vehicle.brand)} ${Str.toTitleCase(vehicle.tradeName)}`;
+            embed.setDescription(`\`${formattedLicense}\` — **${name}**`);
+        } else {
+            embed.setDescription(`\`${formattedLicense}\``);
+        }
+
+        const meta: string[] = [];
+        if (vehicle?.color) {
+            meta.push(`🎨 ${Str.toTitleCase(vehicle.color)}`);
+        }
+        if (vehicle?.totalHorsepower && vehicle.totalHorsepower !== '0') {
+            const emoji = vehicle.primaryFuelType?.toLowerCase() === 'elektriciteit' ? '⚡' : '⛽';
+            meta.push(`${emoji} ${vehicle.totalHorsepower}PK`);
+        }
+        if (meta.length > 0) {
+            embed.addFields({ name: 'Voertuig', value: meta.join('  -  ') });
+        }
+
+        const timestamp = DateTime.getDiscordTimestamp(spot.createdAt.getTime(), DiscordTimestamps.RELATIVE);
+        const spotter = `Gespot door <@${spot.discordUserId}>, ${timestamp}`;
+
+        if (spot.discordChannelId && spot.discordInteractionId) {
+            const link = `https://discord.com/channels/${spot.discordGuildId}/${spot.discordChannelId}/${spot.discordInteractionId}`;
+            embed.addFields({ name: '​', value: `${spotter} · [bekijk spot](${link})` });
+        } else {
+            embed.addFields({ name: '​', value: spotter });
+        }
+
+        if (spot.comment) {
+            embed.addFields({ name: 'Commentaar', value: Str.limitCharacters(spot.comment, 200) });
+        }
+
+        return embed;
+    }
+}

--- a/src/util/random-spot-view.ts
+++ b/src/util/random-spot-view.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder } from 'discord.js';
+import { ContainerBuilder, SeparatorBuilder, SeparatorSpacingSize, TextDisplayBuilder } from 'discord.js';
 import { RandomSpot } from '../types/random-spot';
 import { Str } from './str';
 import { License } from './license';
@@ -6,18 +6,39 @@ import { DateTime } from './date-time';
 import { DiscordTimestamps } from '../enums/discord-timestamps';
 
 export class RandomSpotView {
-    public static build(spot: RandomSpot): EmbedBuilder {
-        const embed = new EmbedBuilder().setColor(0x5865f2).setTitle('🎲 Random spot');
+    public static build(spot: RandomSpot): ContainerBuilder[] {
+        const container = new ContainerBuilder().setAccentColor(0x5865f2);
 
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent('## 🎲 Random spot'));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(this.title(spot)));
+
+        const body = this.buildBody(spot);
+        if (body.length > 0) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(body.join('\n')));
+        }
+
+        container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(this.spotterLine(spot)));
+
+        return [container];
+    }
+
+    private static title(spot: RandomSpot): string {
         const vehicle = spot.vehicle;
         const formattedLicense = License.format(spot.license) || spot.license;
 
         if (vehicle?.brand && vehicle?.tradeName) {
             const name = `${Str.toTitleCase(vehicle.brand)} ${Str.toTitleCase(vehicle.tradeName)}`;
-            embed.setDescription(`\`${formattedLicense}\` — **${name}**`);
-        } else {
-            embed.setDescription(`\`${formattedLicense}\``);
+            return `\`${formattedLicense}\` — **${name}**`;
         }
+
+        return `\`${formattedLicense}\``;
+    }
+
+    private static buildBody(spot: RandomSpot): string[] {
+        const vehicle = spot.vehicle;
+        const body: string[] = [];
 
         const meta: string[] = [];
         if (vehicle?.color) {
@@ -28,23 +49,25 @@ export class RandomSpotView {
             meta.push(`${emoji} ${vehicle.totalHorsepower}PK`);
         }
         if (meta.length > 0) {
-            embed.addFields({ name: 'Voertuig', value: meta.join('  -  ') });
-        }
-
-        const timestamp = DateTime.getDiscordTimestamp(spot.createdAt.getTime(), DiscordTimestamps.RELATIVE);
-        const spotter = `Gespot door <@${spot.discordUserId}>, ${timestamp}`;
-
-        if (spot.discordChannelId && spot.discordInteractionId) {
-            const link = `https://discord.com/channels/${spot.discordGuildId}/${spot.discordChannelId}/${spot.discordInteractionId}`;
-            embed.addFields({ name: '​', value: `${spotter} · [bekijk spot](${link})` });
-        } else {
-            embed.addFields({ name: '​', value: spotter });
+            body.push(meta.join('  -  '));
         }
 
         if (spot.comment) {
-            embed.addFields({ name: 'Commentaar', value: Str.limitCharacters(spot.comment, 200) });
+            body.push(`💬 _${Str.limitCharacters(spot.comment, 200)}_`);
         }
 
-        return embed;
+        return body;
+    }
+
+    private static spotterLine(spot: RandomSpot): string {
+        const timestamp = DateTime.getDiscordTimestamp(spot.createdAt.getTime(), DiscordTimestamps.RELATIVE);
+        const spotter = `-# Gespot door <@${spot.discordUserId}>, ${timestamp}`;
+
+        if (spot.discordChannelId && spot.discordInteractionId) {
+            const link = `https://discord.com/channels/${spot.discordGuildId}/${spot.discordChannelId}/${spot.discordInteractionId}`;
+            return `${spotter} · [bekijk spot](${link})`;
+        }
+
+        return spotter;
     }
 }

--- a/tests/util/random-spot-view.spec.ts
+++ b/tests/util/random-spot-view.spec.ts
@@ -1,6 +1,20 @@
 import { RandomSpotView } from '../../src/util/random-spot-view';
 import { RandomSpot } from '../../src/types/random-spot';
 
+function textContents(containers: ReturnType<typeof RandomSpotView.build>): string {
+    const contents: string[] = [];
+
+    for (const container of containers) {
+        for (const component of container.toJSON().components) {
+            if ('content' in component && typeof component.content === 'string') {
+                contents.push(component.content);
+            }
+        }
+    }
+
+    return contents.join('\n');
+}
+
 const baseSpot: RandomSpot = {
     license: 'AB123C',
     comment: null,
@@ -19,13 +33,13 @@ const baseSpot: RandomSpot = {
 };
 
 describe('RandomSpotView', () => {
-    it('renders the vehicle name, plate and metadata', () => {
-        const embed = RandomSpotView.build(baseSpot).toJSON();
+    it('renders the vehicle name, plate and metadata in a components v2 container', () => {
+        const contents = textContents(RandomSpotView.build(baseSpot));
 
-        expect(embed.description).toBe('`AB-123-C` — **Volkswagen Golf**');
-        const vehicleField = (embed.fields ?? []).find((field) => field.name === 'Voertuig');
-        expect(vehicleField?.value).toContain('🎨 Zwart');
-        expect(vehicleField?.value).toContain('⛽ 110PK');
+        expect(contents).toContain('## 🎲 Random spot');
+        expect(contents).toContain('`AB-123-C` — **Volkswagen Golf**');
+        expect(contents).toContain('🎨 Zwart');
+        expect(contents).toContain('⛽ 110PK');
     });
 
     it('uses a lightning emoji for electric vehicles', () => {
@@ -34,26 +48,28 @@ describe('RandomSpotView', () => {
             vehicle: { ...baseSpot.vehicle!, primaryFuelType: 'Elektriciteit' },
         };
 
-        const embed = RandomSpotView.build(electric).toJSON();
-        const vehicleField = (embed.fields ?? []).find((field) => field.name === 'Voertuig');
-
-        expect(vehicleField?.value).toContain('⚡ 110PK');
+        expect(textContents(RandomSpotView.build(electric))).toContain('⚡ 110PK');
     });
 
     it('links to the original spot message', () => {
-        const embed = RandomSpotView.build(baseSpot).toJSON();
-        const spotterField = (embed.fields ?? []).find((field) => field.value.includes('Gespot door'));
+        const contents = textContents(RandomSpotView.build(baseSpot));
 
-        expect(spotterField?.value).toContain('<@user-1>');
-        expect(spotterField?.value).toContain('https://discord.com/channels/guild-1/chan-1/int-1');
+        expect(contents).toContain('Gespot door <@user-1>');
+        expect(contents).toContain('https://discord.com/channels/guild-1/chan-1/int-1');
+    });
+
+    it('shows the comment when present', () => {
+        const withComment: RandomSpot = { ...baseSpot, comment: 'mooie wagen' };
+
+        expect(textContents(RandomSpotView.build(withComment))).toContain('💬 _mooie wagen_');
     });
 
     it('falls back to just the plate when the vehicle is unknown', () => {
         const unknown: RandomSpot = { ...baseSpot, vehicle: null };
 
-        const embed = RandomSpotView.build(unknown).toJSON();
+        const contents = textContents(RandomSpotView.build(unknown));
 
-        expect(embed.description).toBe('`AB-123-C`');
-        expect((embed.fields ?? []).some((field) => field.name === 'Voertuig')).toBe(false);
+        expect(contents).toContain('`AB-123-C`');
+        expect(contents).not.toContain('🎨');
     });
 });

--- a/tests/util/random-spot-view.spec.ts
+++ b/tests/util/random-spot-view.spec.ts
@@ -1,0 +1,59 @@
+import { RandomSpotView } from '../../src/util/random-spot-view';
+import { RandomSpot } from '../../src/types/random-spot';
+
+const baseSpot: RandomSpot = {
+    license: 'AB123C',
+    comment: null,
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    discordUserId: 'user-1',
+    discordGuildId: 'guild-1',
+    discordChannelId: 'chan-1',
+    discordInteractionId: 'int-1',
+    vehicle: {
+        brand: 'VOLKSWAGEN',
+        tradeName: 'GOLF',
+        color: 'ZWART',
+        totalHorsepower: '110',
+        primaryFuelType: 'Benzine',
+    },
+};
+
+describe('RandomSpotView', () => {
+    it('renders the vehicle name, plate and metadata', () => {
+        const embed = RandomSpotView.build(baseSpot).toJSON();
+
+        expect(embed.description).toBe('`AB-123-C` — **Volkswagen Golf**');
+        const vehicleField = (embed.fields ?? []).find((field) => field.name === 'Voertuig');
+        expect(vehicleField?.value).toContain('🎨 Zwart');
+        expect(vehicleField?.value).toContain('⛽ 110PK');
+    });
+
+    it('uses a lightning emoji for electric vehicles', () => {
+        const electric: RandomSpot = {
+            ...baseSpot,
+            vehicle: { ...baseSpot.vehicle!, primaryFuelType: 'Elektriciteit' },
+        };
+
+        const embed = RandomSpotView.build(electric).toJSON();
+        const vehicleField = (embed.fields ?? []).find((field) => field.name === 'Voertuig');
+
+        expect(vehicleField?.value).toContain('⚡ 110PK');
+    });
+
+    it('links to the original spot message', () => {
+        const embed = RandomSpotView.build(baseSpot).toJSON();
+        const spotterField = (embed.fields ?? []).find((field) => field.value.includes('Gespot door'));
+
+        expect(spotterField?.value).toContain('<@user-1>');
+        expect(spotterField?.value).toContain('https://discord.com/channels/guild-1/chan-1/int-1');
+    });
+
+    it('falls back to just the plate when the vehicle is unknown', () => {
+        const unknown: RandomSpot = { ...baseSpot, vehicle: null };
+
+        const embed = RandomSpotView.build(unknown).toJSON();
+
+        expect(embed.description).toBe('`AB-123-C`');
+        expect((embed.fields ?? []).some((field) => field.name === 'Voertuig')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds a **`/randomspot`** command that pulls up a random earlier sighting — a fun way to revisit old spots.

- In a **server**: draws a random spot from all server sightings
- In **DMs**: draws from the caller's own sightings
- Shows the vehicle (brand/model, colour, power), who spotted it and when, and a link back to the original message

## How it looks

```
🎲 Random spot
`XY-999-Z` — **Porsche 911**

Voertuig
🎨 Rood  -  ⛽ 450PK

Gespot door @Patrick, 3 maanden geleden · [bekijk spot](…)
```

## Implementation

- `services/random-spot.ts` — one query with `ORDER BY RANDOM()` scoped to guild or user, joining the `Vehicle`.
- `util/random-spot-view.ts` — pure rendering into an `EmbedBuilder`.
- Registered in `CommandCollection`; works in guilds, DMs and private channels.

## Testing

- New unit tests for the view (vehicle rendering, EV emoji, message link, unknown-vehicle fallback).
- Verified randomness and the empty-guild path against a seeded local SQLite DB.
- `npm run build`, `npm run lint`, `npm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)