### PR TITLE
feat: autocomplete kenteken on /k from your spot history

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,6 +51,27 @@ export class Bot {
             this.handleButton(interaction);
             return;
         }
+
+        if (interaction.isAutocomplete()) {
+            this.handleAutocomplete(interaction);
+            return;
+        }
+    }
+
+    private handleAutocomplete(interaction: Interaction): void {
+        if (!interaction.isAutocomplete()) {
+            return;
+        }
+
+        const handlerClass = CommandCollection.getInstance().getCommandHandler(interaction.commandName);
+        if (!handlerClass) {
+            return;
+        }
+
+        const handler = new handlerClass();
+        if (handler.autocomplete) {
+            handler.autocomplete(interaction);
+        }
     }
 
     private handleCommand(interaction: Interaction): void {

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -11,7 +11,9 @@ import {
     SlashCommandBuilder,
     InteractionContextType,
     ApplicationIntegrationType,
+    AutocompleteInteraction,
 } from 'discord.js';
+import { SpotSuggestions } from '../queries/spot-suggestions';
 import { Sightings } from '../services/sightings';
 import { FuelInfo } from '../models/fuel-info';
 import { DateTime } from '../util/date-time';
@@ -32,12 +34,21 @@ export class License extends BaseCommand implements ICommand {
             )
             .setIntegrationTypes(ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall)
             .setDescription('Haal een kenteken op')
-            .addStringOption((option) => option.setName('kenteken').setDescription('Het kenteken').setRequired(true))
+            .addStringOption((option) =>
+                option.setName('kenteken').setDescription('Het kenteken').setRequired(true).setAutocomplete(true)
+            )
             .addStringOption((option) =>
                 option.setName('commentaar').setDescription('Voeg commentaar toe aan je spot')
             );
 
         return builder;
+    }
+
+    public async autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+        const focused = interaction.options.getFocused();
+        const choices = await SpotSuggestions.forUser(interaction.user.id, focused);
+
+        await interaction.respond(choices);
     }
 
     public async handle(): Promise<void> {

--- a/src/interfaces/command.ts
+++ b/src/interfaces/command.ts
@@ -1,8 +1,10 @@
-import { ChatInputCommandInteraction, Client, SlashCommandBuilder } from 'discord.js';
+import { AutocompleteInteraction, ChatInputCommandInteraction, Client, SlashCommandBuilder } from 'discord.js';
 
 export interface ICommand {
     init(message: ChatInputCommandInteraction, client: Client): ICommand;
     handle(): void | Promise<void>;
 
     register(builder: SlashCommandBuilder): SlashCommandBuilder;
+
+    autocomplete?(interaction: AutocompleteInteraction): void | Promise<void>;
 }

--- a/src/queries/spot-suggestions.ts
+++ b/src/queries/spot-suggestions.ts
@@ -1,0 +1,53 @@
+import { Op, WhereOptions } from 'sequelize';
+import { Sighting } from '../models/sighting';
+import { Vehicle } from '../models/vehicle';
+import { SpotSuggestion } from '../util/spot-suggestion';
+import { SpotChoice } from '../types/spot-choice';
+
+export class SpotSuggestions {
+    private static readonly MAX_CHOICES = 25;
+    private static readonly SCAN_LIMIT = 100;
+
+    public static async forUser(discordUserId: string, query: string): Promise<SpotChoice[]> {
+        const normalized = SpotSuggestion.normalizeQuery(query);
+
+        const where: WhereOptions = normalized
+            ? { discordUserId, license: { [Op.like]: `%${normalized}%` } }
+            : { discordUserId };
+
+        const sightings = await Sighting.findAll({
+            where,
+            order: [['createdAt', 'DESC']],
+            limit: this.SCAN_LIMIT,
+            include: [
+                {
+                    model: Vehicle,
+                    as: 'vehicle',
+                    required: false,
+                },
+            ],
+        });
+
+        const seen = new Set<string>();
+        const choices: SpotChoice[] = [];
+
+        for (const sighting of sightings) {
+            if (seen.has(sighting.license)) {
+                continue;
+            }
+            seen.add(sighting.license);
+
+            const vehicle = sighting.vehicle;
+            choices.push({
+                name: SpotSuggestion.label(sighting.license, vehicle?.brand ?? null, vehicle?.tradeName ?? null),
+                value: sighting.license,
+            });
+
+            if (choices.length >= this.MAX_CHOICES) {
+                break;
+            }
+        }
+
+        return choices;
+    }
+}

--- a/src/types/spot-choice.ts
+++ b/src/types/spot-choice.ts
@@ -1,0 +1,4 @@
+export interface SpotChoice {
+    name: string;
+    value: string;
+}

--- a/src/util/spot-suggestion.ts
+++ b/src/util/spot-suggestion.ts
@@ -1,0 +1,19 @@
+import { Str } from './str';
+import { License } from './license';
+
+export class SpotSuggestion {
+    public static normalizeQuery(input: string): string {
+        return input.toUpperCase().replace(/[-\s]/g, '');
+    }
+
+    public static label(license: string, brand: string | null, tradeName: string | null): string {
+        const formatted = License.format(license) || license;
+
+        if (brand && tradeName) {
+            const name = `${Str.toTitleCase(brand)} ${Str.toTitleCase(tradeName)}`;
+            return Str.limitCharacters(`${formatted} (${name})`, 100);
+        }
+
+        return formatted;
+    }
+}

--- a/tests/util/spot-suggestion.spec.ts
+++ b/tests/util/spot-suggestion.spec.ts
@@ -1,0 +1,27 @@
+import { SpotSuggestion } from '../../src/util/spot-suggestion';
+
+describe('SpotSuggestion.normalizeQuery', () => {
+    it('uppercases and strips dashes and spaces', () => {
+        expect(SpotSuggestion.normalizeQuery('ab-123-c')).toBe('AB123C');
+        expect(SpotSuggestion.normalizeQuery(' xy 999 z ')).toBe('XY999Z');
+    });
+
+    it('returns an empty string for an empty query', () => {
+        expect(SpotSuggestion.normalizeQuery('')).toBe('');
+    });
+});
+
+describe('SpotSuggestion.label', () => {
+    it('shows the formatted plate with brand and model', () => {
+        expect(SpotSuggestion.label('AB123C', 'VOLKSWAGEN', 'GOLF')).toBe('AB-123-C (Volkswagen Golf)');
+    });
+
+    it('falls back to the formatted plate when there is no vehicle data', () => {
+        expect(SpotSuggestion.label('AB123C', null, null)).toBe('AB-123-C');
+    });
+
+    it('caps the label at 100 characters', () => {
+        const label = SpotSuggestion.label('AB123C', 'VOLKSWAGEN', 'X'.repeat(200));
+        expect(label.length).toBeLessThanOrEqual(100);
+    });
+});


### PR DESCRIPTION
## What

The **kenteken** option on `/k` now autocompletes from the plates **you've spotted before**, so you can quickly re-look-up a car without retyping it.

- Suggestions are matched as you type — case- and dash-insensitive (`ab-1` matches `AB-123-C`)
- Each suggestion is labelled with the vehicle brand + model
- De-duplicated and ordered most-recent-first, capped at Discord's 25-choice limit
- With an empty input it shows your most recent unique spots

## How it looks

```
/k kenteken: XY▮
  ┌ XY-999-Z (Porsche 911)
  └ …
```

## Implementation

- `services/spot-suggestions.ts` — queries the caller's sightings (`LIKE` on the normalised plate), joins `Vehicle`, de-dupes by plate.
- `util/spot-suggestion.ts` — pure query-normalisation and label building.
- `ICommand` gains an optional `autocomplete()` hook; `Bot` dispatches `isAutocomplete()` interactions to it, mirroring the existing command/button routing. `License` implements the hook and marks the option `setAutocomplete(true)`.

## Testing

- Unit tests for the pure normalisation and label logic (including the 100-char cap).
- Verified the suggestion service end-to-end against a seeded local SQLite DB (prefix match, dash-insensitivity, de-dup, empty-input, unknown-user).
- `npm run build`, `npm run lint`, `npm test` all green (70 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)