### PR TITLE
feat: add /expensive and /oldest superlative boards

### DIFF
--- a/src/commands/expensive.ts
+++ b/src/commands/expensive.ts
@@ -1,0 +1,30 @@
+import { ICommand } from '../interfaces/command';
+import { BaseCommand } from './base-command';
+import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType } from 'discord.js';
+import { Superlatives } from '../queries/superlatives';
+import { SuperlativesView } from '../util/superlatives-view';
+
+export class Expensive extends BaseCommand implements ICommand {
+    public register(builder: SlashCommandBuilder): SlashCommandBuilder {
+        return builder
+            .setName('expensive')
+            .setContexts(InteractionContextType.Guild)
+            .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+            .setDescription("De duurste auto's die in deze server zijn gespot");
+    }
+
+    public async handle(): Promise<void> {
+        await this.interaction.deferReply();
+
+        const guildId = this.interaction.guildId;
+        if (!guildId) {
+            await this.interaction.followUp('Dit commando kan alleen in een server worden gebruikt.');
+            return;
+        }
+
+        const entries = await Superlatives.mostExpensive(guildId);
+        const embed = SuperlativesView.build('💰 Duurste spots', entries, 'price');
+
+        await this.interaction.followUp({ embeds: [embed], allowedMentions: { users: [] } });
+    }
+}

--- a/src/commands/oldest.ts
+++ b/src/commands/oldest.ts
@@ -1,0 +1,30 @@
+import { ICommand } from '../interfaces/command';
+import { BaseCommand } from './base-command';
+import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType } from 'discord.js';
+import { Superlatives } from '../queries/superlatives';
+import { SuperlativesView } from '../util/superlatives-view';
+
+export class Oldest extends BaseCommand implements ICommand {
+    public register(builder: SlashCommandBuilder): SlashCommandBuilder {
+        return builder
+            .setName('oldest')
+            .setContexts(InteractionContextType.Guild)
+            .setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+            .setDescription("De oudste auto's die in deze server zijn gespot");
+    }
+
+    public async handle(): Promise<void> {
+        await this.interaction.deferReply();
+
+        const guildId = this.interaction.guildId;
+        if (!guildId) {
+            await this.interaction.followUp('Dit commando kan alleen in een server worden gebruikt.');
+            return;
+        }
+
+        const entries = await Superlatives.oldest(guildId);
+        const embed = SuperlativesView.build('🕰️ Oudste spots', entries, 'age');
+
+        await this.interaction.followUp({ embeds: [embed], allowedMentions: { users: [] } });
+    }
+}

--- a/src/queries/superlatives.ts
+++ b/src/queries/superlatives.ts
@@ -1,0 +1,51 @@
+import { Sighting } from '../models/sighting';
+import { Vehicle } from '../models/vehicle';
+import { SuperlativesRanker } from '../util/superlatives-ranker';
+import { RankedVehicle, SuperlativeSpot } from '../types/superlatives';
+
+export class Superlatives {
+    private static readonly LIMIT = 10;
+
+    public static async mostExpensive(discordGuildId: string): Promise<RankedVehicle[]> {
+        const spots = await this.loadGuildSpots(discordGuildId);
+        return SuperlativesRanker.byPrice(spots, this.LIMIT);
+    }
+
+    public static async oldest(discordGuildId: string): Promise<RankedVehicle[]> {
+        const spots = await this.loadGuildSpots(discordGuildId);
+        return SuperlativesRanker.byAge(spots, this.LIMIT);
+    }
+
+    private static async loadGuildSpots(discordGuildId: string): Promise<SuperlativeSpot[]> {
+        const sightings = await Sighting.findAll({
+            where: { discordGuildId },
+            include: [
+                {
+                    model: Vehicle,
+                    as: 'vehicle',
+                    required: true,
+                },
+            ],
+        });
+
+        const spots: SuperlativeSpot[] = [];
+        for (const sighting of sightings) {
+            const vehicle = sighting.vehicle;
+            if (!vehicle) {
+                continue;
+            }
+
+            spots.push({
+                license: sighting.license,
+                brand: vehicle.brand,
+                tradeName: vehicle.tradeName,
+                price: vehicle.price,
+                dateFirstAllowed: vehicle.dateFirstAllowed ?? null,
+                spotterUserId: sighting.discordUserId,
+                spottedAt: sighting.createdAt,
+            });
+        }
+
+        return spots;
+    }
+}

--- a/src/services/command-collection.ts
+++ b/src/services/command-collection.ts
@@ -7,6 +7,8 @@ import { Ping } from '../commands/ping';
 import { Status } from '../commands/status';
 import { UserSpots } from '../commands/userspots';
 import { ServerSpots } from '../commands/serverspots';
+import { Expensive } from '../commands/expensive';
+import { Oldest } from '../commands/oldest';
 
 export class CommandCollection {
     private static instance: CommandCollection;
@@ -17,7 +19,7 @@ export class CommandCollection {
     }
 
     private getCommandClasses(): CommandConstructor[] {
-        return [License, Ping, Status, UserSpots, ServerSpots];
+        return [License, Ping, Status, UserSpots, ServerSpots, Expensive, Oldest];
     }
 
     private getCommands(): { builder: SlashCommandBuilder; command: CommandConstructor }[] {

--- a/src/types/superlatives.ts
+++ b/src/types/superlatives.ts
@@ -1,0 +1,20 @@
+export interface SuperlativeSpot {
+    license: string;
+    brand: string | null;
+    tradeName: string | null;
+    price: number | null;
+    dateFirstAllowed: Date | null;
+    spotterUserId: string;
+    spottedAt: Date;
+}
+
+export interface RankedVehicle {
+    license: string;
+    brand: string | null;
+    tradeName: string | null;
+    price: number | null;
+    dateFirstAllowed: Date | null;
+    spotterUserId: string;
+}
+
+export type SuperlativeMode = 'price' | 'age';

--- a/src/util/superlatives-ranker.ts
+++ b/src/util/superlatives-ranker.ts
@@ -1,0 +1,49 @@
+import { RankedVehicle, SuperlativeSpot } from '../types/superlatives';
+
+export class SuperlativesRanker {
+    public static byPrice(spots: SuperlativeSpot[], limit: number): RankedVehicle[] {
+        const deduped = this.dedupeByPlate(spots);
+        const withPrice = deduped.filter((spot) => spot.price !== null);
+        withPrice.sort((a, b) => (b.price ?? 0) - (a.price ?? 0));
+
+        return this.take(withPrice, limit);
+    }
+
+    public static byAge(spots: SuperlativeSpot[], limit: number): RankedVehicle[] {
+        const deduped = this.dedupeByPlate(spots);
+        const withDate = deduped.filter((spot) => spot.dateFirstAllowed !== null);
+        withDate.sort((a, b) => (a.dateFirstAllowed?.getTime() ?? 0) - (b.dateFirstAllowed?.getTime() ?? 0));
+
+        return this.take(withDate, limit);
+    }
+
+    private static dedupeByPlate(spots: SuperlativeSpot[]): SuperlativeSpot[] {
+        const latestByPlate = new Map<string, SuperlativeSpot>();
+
+        for (const spot of spots) {
+            const existing = latestByPlate.get(spot.license);
+            if (!existing || spot.spottedAt.getTime() > existing.spottedAt.getTime()) {
+                latestByPlate.set(spot.license, spot);
+            }
+        }
+
+        return [...latestByPlate.values()];
+    }
+
+    private static take(spots: SuperlativeSpot[], limit: number): RankedVehicle[] {
+        const ranked: RankedVehicle[] = [];
+
+        for (const spot of spots.slice(0, limit)) {
+            ranked.push({
+                license: spot.license,
+                brand: spot.brand,
+                tradeName: spot.tradeName,
+                price: spot.price,
+                dateFirstAllowed: spot.dateFirstAllowed,
+                spotterUserId: spot.spotterUserId,
+            });
+        }
+
+        return ranked;
+    }
+}

--- a/src/util/superlatives-view.ts
+++ b/src/util/superlatives-view.ts
@@ -1,0 +1,59 @@
+import { EmbedBuilder } from 'discord.js';
+import { RankedVehicle, SuperlativeMode } from '../types/superlatives';
+import { Str } from './str';
+import { License } from './license';
+import { formatCurrency } from './format-currency';
+
+export class SuperlativesView {
+    private static readonly MEDALS = ['🥇', '🥈', '🥉'];
+
+    public static build(title: string, entries: RankedVehicle[], mode: SuperlativeMode): EmbedBuilder {
+        const embed = new EmbedBuilder().setColor(0x5865f2).setTitle(title);
+
+        if (entries.length === 0) {
+            embed.setDescription('Er zijn nog geen voertuigen gespot in deze server.');
+            return embed;
+        }
+
+        const lines: string[] = [];
+        entries.forEach((entry, index) => {
+            lines.push(this.line(entry, index, mode));
+        });
+
+        embed.setDescription(lines.join('\n'));
+
+        return embed;
+    }
+
+    private static line(entry: RankedVehicle, index: number, mode: SuperlativeMode): string {
+        const name = this.vehicleName(entry);
+        const value = mode === 'price' ? this.priceValue(entry) : this.ageValue(entry);
+
+        return `${this.rank(index)} **${name}** — ${value} · <@${entry.spotterUserId}>`;
+    }
+
+    private static priceValue(entry: RankedVehicle): string {
+        return entry.price !== null ? formatCurrency(entry.price) : 'onbekend';
+    }
+
+    private static ageValue(entry: RankedVehicle): string {
+        return entry.dateFirstAllowed ? entry.dateFirstAllowed.getFullYear().toString() : 'onbekend';
+    }
+
+    private static vehicleName(entry: RankedVehicle): string {
+        const formattedLicense = License.format(entry.license) || entry.license;
+
+        if (entry.brand && entry.tradeName) {
+            return `${Str.toTitleCase(entry.brand)} ${Str.toTitleCase(entry.tradeName)}`;
+        }
+        if (entry.brand) {
+            return Str.toTitleCase(entry.brand);
+        }
+
+        return formattedLicense;
+    }
+
+    private static rank(index: number): string {
+        return this.MEDALS[index] ?? `**${index + 1}.**`;
+    }
+}

--- a/tests/util/superlatives-ranker.spec.ts
+++ b/tests/util/superlatives-ranker.spec.ts
@@ -1,0 +1,70 @@
+import { SuperlativesRanker } from '../../src/util/superlatives-ranker';
+import { SuperlativeSpot } from '../../src/types/superlatives';
+
+function spot(overrides: Partial<SuperlativeSpot> & { license: string }): SuperlativeSpot {
+    return {
+        brand: 'BRAND',
+        tradeName: 'MODEL',
+        price: null,
+        dateFirstAllowed: null,
+        spotterUserId: 'user-1',
+        spottedAt: new Date('2024-01-01T00:00:00Z'),
+        ...overrides,
+    };
+}
+
+describe('SuperlativesRanker.byPrice', () => {
+    it('sorts vehicles by price descending and drops price-less ones', () => {
+        const ranked = SuperlativesRanker.byPrice(
+            [
+                spot({ license: 'A', price: 30000 }),
+                spot({ license: 'B', price: 145000 }),
+                spot({ license: 'C', price: null }),
+                spot({ license: 'D', price: 52000 }),
+            ],
+            10
+        );
+
+        expect(ranked.map((entry) => entry.license)).toEqual(['B', 'D', 'A']);
+    });
+
+    it('respects the limit', () => {
+        const ranked = SuperlativesRanker.byPrice(
+            [spot({ license: 'A', price: 1 }), spot({ license: 'B', price: 2 }), spot({ license: 'C', price: 3 })],
+            2
+        );
+
+        expect(ranked).toHaveLength(2);
+        expect(ranked[0].license).toBe('C');
+    });
+});
+
+describe('SuperlativesRanker.byAge', () => {
+    it('sorts vehicles oldest first and drops date-less ones', () => {
+        const ranked = SuperlativesRanker.byAge(
+            [
+                spot({ license: 'A', dateFirstAllowed: new Date('2019-01-01') }),
+                spot({ license: 'B', dateFirstAllowed: new Date('1978-01-01') }),
+                spot({ license: 'C', dateFirstAllowed: null }),
+            ],
+            10
+        );
+
+        expect(ranked.map((entry) => entry.license)).toEqual(['B', 'A']);
+    });
+});
+
+describe('SuperlativesRanker de-duplication', () => {
+    it('keeps only the most recent spot per plate', () => {
+        const ranked = SuperlativesRanker.byPrice(
+            [
+                spot({ license: 'A', price: 30000, spotterUserId: 'old', spottedAt: new Date('2023-01-01') }),
+                spot({ license: 'A', price: 30000, spotterUserId: 'new', spottedAt: new Date('2024-06-01') }),
+            ],
+            10
+        );
+
+        expect(ranked).toHaveLength(1);
+        expect(ranked[0].spotterUserId).toBe('new');
+    });
+});


### PR DESCRIPTION
## What

Two "hall of fame" leaderboards over the cars spotted in a server:

- **`/expensive`** — the most expensive cars ever spotted (by catalogue price)
- **`/oldest`** — the oldest cars ever spotted (by date of first admission)

Each entry credits the spotter (the most recent one, if a plate was spotted more than once).

## How it looks

```
💰 Duurste spots
🥇 **Porsche 911** — € 145.000 · @Kef
🥈 **Audi RS6** — € 118.000 · @Patrick
🥉 **Tesla Model 3** — € 52.000 · @friend
```

## Implementation

- `util/superlatives-ranker.ts` — **pure** logic: de-duplicate by plate (keep most recent spotter), sort by price/age, cap to the top 10.
- `services/superlatives.ts` — loads the guild's sightings that have vehicle data and delegates to the ranker.
- `util/superlatives-view.ts` — one medalled ranking view shared by both commands, parameterised by `price`/`age`.

## Testing

- Unit tests for the ranker (price sort + limit, age sort, drop of missing values, de-dup keeping the newest spotter).
- Verified both boards and the empty state against a seeded local SQLite DB.
- `npm run build`, `npm run lint`, `npm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)