### PR TITLE
perf: add indexes on Sightings hot columns

### DIFF
--- a/database/migrations/20260710120000-add-sightings-indexes.js
+++ b/database/migrations/20260710120000-add-sightings-indexes.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface) {
+        await queryInterface.addIndex('Sightings', ['discordGuildId'], {
+            name: 'sightings_discord_guild_id',
+        });
+        await queryInterface.addIndex('Sightings', ['discordUserId'], {
+            name: 'sightings_discord_user_id',
+        });
+        await queryInterface.addIndex('Sightings', ['license'], {
+            name: 'sightings_license',
+        });
+        await queryInterface.addIndex('Sightings', ['vehicleId'], {
+            name: 'sightings_vehicle_id',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('Sightings', 'sightings_discord_guild_id');
+        await queryInterface.removeIndex('Sightings', 'sightings_discord_user_id');
+        await queryInterface.removeIndex('Sightings', 'sightings_license');
+        await queryInterface.removeIndex('Sightings', 'sightings_vehicle_id');
+    },
+};


### PR DESCRIPTION
## What

Adds database indexes on the `Sightings` columns used for filtering, grouping and joining — closing the investigation in #32.

Indexed: `discordGuildId`, `discordUserId`, `license`, `vehicleId`.

`Vehicles.license` is already `unique` (and therefore indexed), so no change was needed there.

## Why

These columns back nearly every read: `/userspots`, `/serverspots`, the `/k` "eerder gespot" list, and the newer leaderboard / stats / superlative / search queries. Without indexes SQLite full-scans `Sightings` on each, which gets slower as the table grows (and as multi-guild usage increases — exactly the concern raised in #32).

## Verification

Applied the migration to a local DB and checked the planner:

```
-- before: SCAN Sightings
-- after:
EXPLAIN QUERY PLAN SELECT discordUserId, COUNT(*) FROM Sightings WHERE discordGuildId=? GROUP BY discordUserId;
  SEARCH Sightings USING INDEX sightings_discord_guild_id (discordGuildId=?)

EXPLAIN QUERY PLAN SELECT * FROM Sightings WHERE license=?;
  SEARCH Sightings USING INDEX sightings_license (license=?)
```

Migration `up` → `down` → `up` all run cleanly (indexes created, dropped, recreated).

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)