### PR TITLE
fix: store guild id from interaction payload instead of cache

### DIFF
--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -143,7 +143,7 @@ export class License extends BaseCommand implements ICommand {
             this.interaction.user,
             this.interaction.id,
             this.interaction.channelId,
-            this.interaction.guild,
+            this.interaction.guildId,
             this.getComment(),
             vehicleId
         );

--- a/src/services/sightings.ts
+++ b/src/services/sightings.ts
@@ -1,6 +1,6 @@
 import { Sighting } from '../models/sighting';
 import { Vehicle } from '../models/vehicle';
-import { escapeMarkdown, Guild, User } from 'discord.js';
+import { escapeMarkdown, User } from 'discord.js';
 import { DateTime } from '../util/date-time';
 import { DiscordTimestamps } from '../enums/discord-timestamps';
 import { Str } from '../util/str';
@@ -173,14 +173,14 @@ export class Sightings {
         author: User,
         interactionId: string,
         channelId: string | null,
-        guild: Guild | null,
+        discordGuildId: string | null,
         comment: null | string = null,
         vehicleId: number | null
     ): void {
         Sighting.create({
             license,
             discordUserId: author.id,
-            discordGuildId: guild?.id,
+            discordGuildId: discordGuildId ?? undefined,
             discordChannelId: channelId ?? undefined,
             discordInteractionId: interactionId,
             comment: comment ? Str.limitCharacters(escapeMarkdown(comment), 255) : null,


### PR DESCRIPTION
## Bug

`Sightings.insert` stored `discordGuildId` from `interaction.guild?.id` — a **guild-cache lookup**. The client is constructed with `intents: []`, so the guild cache can be empty and `interaction.guild` resolves to `null`. Result: sightings are saved **without a guild id**, while every read path (`/serverspots`, the "Eerder gespot door" list) filters on `interaction.guildId` from the interaction payload, which *is* always set.

Found while testing the new guild-scoped features locally: every `/k` claimed to be the first spot of that model and `/leaderboard` stayed empty, because no sighting ever matched the guild filter.

```
sqlite> SELECT license, discordGuildId FROM Sightings;
X898PL|          ← empty
X897PL|          ← empty
```

## Fix

`Sightings.insert` now takes the guild id (`string | null`) directly, and the `/k` command passes `this.interaction.guildId` — the payload value, independent of cache/intents. Same approach the read paths already use.

## Testing

- `npm run build`, `npm run lint`, `npm test` green.
- Re-tested locally: after the fix new sightings carry the guild id, the first-spotter badge only appears once per model, and the leaderboard fills up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)