### PR TITLE
feat: redesign /k output with components v2

### DIFF
--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -143,7 +143,7 @@ export class License extends BaseCommand implements ICommand {
             this.interaction.user,
             this.interaction.id,
             this.interaction.channelId,
-            this.interaction.guild,
+            this.interaction.guildId,
             this.getComment(),
             vehicleId
         );

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -1,27 +1,17 @@
 import { ICommand } from '../interfaces/command';
 import { BaseCommand } from './base-command';
 import { VehicleInfo } from '../models/vehicle-info';
-import { Str } from '../util/str';
 import { License as LicenseUtil } from '../util/license';
-import {
-    ActionRowBuilder,
-    ButtonBuilder,
-    EmbedBuilder,
-    ButtonStyle,
-    SlashCommandBuilder,
-    InteractionContextType,
-    ApplicationIntegrationType,
-} from 'discord.js';
+import { SlashCommandBuilder, InteractionContextType, ApplicationIntegrationType, MessageFlags } from 'discord.js';
 import { Sightings } from '../services/sightings';
 import { FuelInfo } from '../models/fuel-info';
-import { DateTime } from '../util/date-time';
-import { DiscordTimestamps } from '../enums/discord-timestamps';
 import { calculateHorsePower } from '../util/calulate-horse-power';
 import { StatensVegvesenFullData } from '../types/norwegian-statens-vegvesen';
 import { Vehicles } from '../services/vehicles';
 import { Vehicle } from '../models';
 import { FirstSpotter } from '../queries/first-spotter';
 import { FirstSpotBadge } from '../util/first-spot-badge';
+import { LicenseView } from '../util/license-view';
 
 export class License extends BaseCommand implements ICommand {
     public register(builder: SlashCommandBuilder): SlashCommandBuilder {
@@ -62,19 +52,20 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
-        const [vehicleInfo, fuelInfo, sightings] = await Promise.all([
+        const [vehicleInfo, fuelInfo, sightings, previousSpotCount] = await Promise.all([
             VehicleInfo.get(license),
             FuelInfo.get(license),
             Sightings.list(license, this.interaction.guildId, this.interaction.user.id),
+            Sightings.countForLicense(license, this.interaction.guildId),
         ]);
 
         if (!vehicleInfo) {
             if (sightings) {
-                const response = new EmbedBuilder()
-                    .setTitle(`Kenteken ${license} niet gevonden, rdw heeft m niet meer (rip)`)
-                    .addFields([{ name: 'Eerder gespot door:', value: sightings.list }])
-                    .setFooter({ text: LicenseUtil.format(license) });
-                await this.interaction.followUp({ embeds: [response] });
+                await this.interaction.followUp({
+                    components: LicenseView.buildNotFound(license, LicenseUtil.format(license), sightings.list),
+                    flags: MessageFlags.IsComponentsV2,
+                    allowedMentions: { users: [] },
+                });
             } else {
                 this.interaction.followUp('Ik kon dat kenteken niet vindn kerol');
             }
@@ -87,60 +78,22 @@ export class License extends BaseCommand implements ICommand {
             vehicleInfo.handelsbenaming
         );
 
-        const fuelDescription: string[] = [];
-        fuelInfo.engines.forEach((engine) => {
-            fuelDescription.push(engine.getHorsePowerDescription());
+        const components = LicenseView.build({
+            vehicleInfo,
+            fuelInfo,
+            formattedLicense: LicenseUtil.format(license),
+            vehicleType: LicenseUtil.getVehicleType(license),
+            badge: isFirstModel ? FirstSpotBadge.message(vehicleInfo.merk, vehicleInfo.handelsbenaming) : null,
+            comment: this.getComment(),
+            sightingsList: sightings ? sightings.list : null,
+            spotCount: previousSpotCount !== null ? previousSpotCount + 1 : null,
         });
 
-        const meta = [
-            `🎨 ${Str.toTitleCase(vehicleInfo.eerste_kleur)}`,
-            vehicleInfo.getPriceDescription(),
-            `🗓️ ${DateTime.getDiscordTimestamp(
-                vehicleInfo.getConstructionDateTimestamp(),
-                DiscordTimestamps.SHORT_DATE
-            )}`,
-        ];
-
-        const description = fuelDescription.join('  -  ') + '\n' + meta.join('  -  ');
-
-        const formattedLicense = LicenseUtil.format(license);
-        const vehicleType = LicenseUtil.getVehicleType(license);
-
-        const response = new EmbedBuilder()
-            .setTitle(`${Str.toTitleCase(vehicleInfo.merk)} ${Str.toTitleCase(vehicleInfo.handelsbenaming)}`)
-            .setDescription(description)
-            .setThumbnail(
-                `https://www.kentekencheck.nl/assets/img/brands/${Str.humanToSnakeCase(vehicleInfo.merk)}.png`
-            )
-            .setFooter({ text: vehicleType ? `${formattedLicense} • ${vehicleType}` : formattedLicense });
-
-        if (isFirstModel) {
-            response.addFields([
-                { name: '🥇 Primeur', value: FirstSpotBadge.message(vehicleInfo.merk, vehicleInfo.handelsbenaming) },
-            ]);
-        }
-
-        const comment = this.getComment();
-        if (comment) {
-            response.addFields([{ name: 'Commentaar:', value: comment }]);
-        }
-
-        if (sightings) {
-            response.addFields([{ name: 'Eerder gespot door:', value: sightings.list }]);
-        }
-
-        const links = new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-                .setLabel('Kentekencheck')
-                .setStyle(ButtonStyle.Link)
-                .setURL(`https://kentekencheck.nl/kenteken?i=${license}`),
-            new ButtonBuilder()
-                .setLabel('Finnik')
-                .setStyle(ButtonStyle.Link)
-                .setURL(`https://finnik.nl/kenteken/${license}/gratis`)
-        );
-
-        await this.interaction.followUp({ embeds: [response], components: [links] });
+        await this.interaction.followUp({
+            components,
+            flags: MessageFlags.IsComponentsV2,
+            allowedMentions: { users: [] },
+        });
 
         const vehicle = await this.insertVehicle(vehicleInfo, fuelInfo, 'nl');
 
@@ -172,46 +125,43 @@ export class License extends BaseCommand implements ICommand {
     }
 
     protected async getNorwegianInfo(license: string) {
-        const repsone = await fetch(
+        const response = await fetch(
             `https://kjoretoyoppslag.atlas.vegvesen.no/ws/no/vegvesen/kjoretoy/kjoretoyoppslag/v1/oppslag/raw/${license}`
         );
 
-        const data: StatensVegvesenFullData = await repsone.json();
+        const data: StatensVegvesenFullData = await response.json();
 
-        const brand = Str.toTitleCase(
-            data.kjoretoy.godkjenning.tekniskGodkjenning.tekniskeData.generelt.merke[0].merke
-        );
-        const model = Str.toTitleCase(
-            data.kjoretoy.godkjenning.tekniskGodkjenning.tekniskeData.generelt.handelsbetegnelse[0]
-        );
+        const brand = data.kjoretoy.godkjenning.tekniskGodkjenning.tekniskeData.generelt.merke[0]?.merke ?? '';
+        const model = data.kjoretoy.godkjenning.tekniskGodkjenning.tekniskeData.generelt.handelsbetegnelse[0] ?? '';
 
         const engines = data.kjoretoy.godkjenning.tekniskGodkjenning.tekniskeData.motorOgDrivverk.motor;
 
         const fuelDescription: string[] = [];
-
         engines.forEach((engine) => {
-            const emoji = engine.drivstoff[0].drivstoffKode.kodeNavn === 'Elektrisk' ? '⚡' : '⛽';
+            const fuel = engine.drivstoff[0];
+            if (!fuel?.maksNettoEffekt) {
+                return;
+            }
 
-            fuelDescription.push(`${emoji} ${calculateHorsePower(engine.drivstoff[0].maksNettoEffekt)}PK`);
+            const emoji = fuel.drivstoffKode.kodeNavn === 'Elektrisk' ? '⚡' : '⛽';
+            fuelDescription.push(`${emoji} ${calculateHorsePower(fuel.maksNettoEffekt)}PK`);
         });
 
-        const meta = [
-            `🗓️ ${DateTime.getDiscordTimestamp(
-                new Date(data.kjoretoy.godkjenning.forstegangsGodkjenning.forstegangRegistrertDato).getTime(),
-                DiscordTimestamps.SHORT_DATE
-            )}`,
-        ];
+        const registeredTimestamp = new Date(
+            data.kjoretoy.godkjenning.forstegangsGodkjenning.forstegangRegistrertDato
+        ).getTime();
 
-        const description = fuelDescription.join('  -  ') + '\n' + meta.join('  -  ');
+        const components = LicenseView.buildNorwegian({
+            license,
+            brand,
+            model,
+            fuelDescription: fuelDescription.join('  ·  '),
+            registeredTimestamp: isNaN(registeredTimestamp) ? 0 : registeredTimestamp,
+        });
 
-        // forstegangRegistrertDato
-
-        const response = new EmbedBuilder()
-            .setTitle(`${Str.toTitleCase(brand)} ${Str.toTitleCase(model)}`)
-            .setDescription(description)
-            .setThumbnail(`https://www.kentekencheck.nl/assets/img/brands/${Str.humanToSnakeCase(brand)}.png`)
-            .setFooter({ text: `🇳🇴 ${license}` });
-
-        await this.interaction.followUp({ embeds: [response] });
+        await this.interaction.followUp({
+            components,
+            flags: MessageFlags.IsComponentsV2,
+        });
     }
 }

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -20,6 +20,8 @@ import { calculateHorsePower } from '../util/calulate-horse-power';
 import { StatensVegvesenFullData } from '../types/norwegian-statens-vegvesen';
 import { Vehicles } from '../services/vehicles';
 import { Vehicle } from '../models';
+import { FirstSpotter } from '../queries/first-spotter';
+import { FirstSpotBadge } from '../util/first-spot-badge';
 
 export class License extends BaseCommand implements ICommand {
     public register(builder: SlashCommandBuilder): SlashCommandBuilder {
@@ -79,6 +81,12 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
+        const isFirstModel = await FirstSpotter.isFirstModelInGuild(
+            this.interaction.guildId,
+            vehicleInfo.merk,
+            vehicleInfo.handelsbenaming
+        );
+
         const fuelDescription: string[] = [];
         fuelInfo.engines.forEach((engine) => {
             fuelDescription.push(engine.getHorsePowerDescription());
@@ -105,6 +113,12 @@ export class License extends BaseCommand implements ICommand {
                 `https://www.kentekencheck.nl/assets/img/brands/${Str.humanToSnakeCase(vehicleInfo.merk)}.png`
             )
             .setFooter({ text: vehicleType ? `${formattedLicense} • ${vehicleType}` : formattedLicense });
+
+        if (isFirstModel) {
+            response.addFields([
+                { name: '🥇 Primeur', value: FirstSpotBadge.message(vehicleInfo.merk, vehicleInfo.handelsbenaming) },
+            ]);
+        }
 
         const comment = this.getComment();
         if (comment) {

--- a/src/models/vehicle-info.ts
+++ b/src/models/vehicle-info.ts
@@ -41,6 +41,7 @@ export class VehicleInfo extends BaseModel {
     public datum_eerste_toelating_dt = '';
     public datum_eerste_tenaamstelling_in_nederland_dt = '';
     public catalogusprijs = '';
+    public vervaldatum_apk_dt = '';
 
     public constructor(data: Record<string, unknown>) {
         super();
@@ -87,5 +88,25 @@ export class VehicleInfo extends BaseModel {
         }
 
         return `💵 ${formatCurrency(price)}`;
+    }
+
+    public getApkExpiryTimestamp(): number | null {
+        if (!this.vervaldatum_apk_dt) {
+            return null;
+        }
+
+        const timestamp = new Date(this.vervaldatum_apk_dt).getTime();
+
+        return isNaN(timestamp) ? null : timestamp;
+    }
+
+    public getFirstRegistrationInNetherlandsTimestamp(): number | null {
+        if (!this.datum_eerste_tenaamstelling_in_nederland_dt) {
+            return null;
+        }
+
+        const timestamp = new Date(this.datum_eerste_tenaamstelling_in_nederland_dt).getTime();
+
+        return isNaN(timestamp) ? null : timestamp;
     }
 }

--- a/src/queries/first-spotter.ts
+++ b/src/queries/first-spotter.ts
@@ -1,0 +1,28 @@
+import { Sighting } from '../models/sighting';
+import { Vehicle } from '../models/vehicle';
+
+export class FirstSpotter {
+    public static async isFirstModelInGuild(
+        discordGuildId: string | null,
+        brand: string,
+        tradeName: string
+    ): Promise<boolean> {
+        if (!discordGuildId || !brand || !tradeName) {
+            return false;
+        }
+
+        const count = await Sighting.count({
+            where: { discordGuildId },
+            include: [
+                {
+                    model: Vehicle,
+                    as: 'vehicle',
+                    required: true,
+                    where: { brand, tradeName },
+                },
+            ],
+        });
+
+        return count === 0;
+    }
+}

--- a/src/services/sightings.ts
+++ b/src/services/sightings.ts
@@ -103,6 +103,14 @@ export class Sightings {
         };
     }
 
+    public static async countForLicense(license: string, discordGuildId: string | null): Promise<number | null> {
+        if (!discordGuildId) {
+            return null;
+        }
+
+        return Sighting.count({ where: { license, discordGuildId } });
+    }
+
     public static async list(
         license: string,
         discordGuildId: string | null,

--- a/src/services/sightings.ts
+++ b/src/services/sightings.ts
@@ -1,6 +1,6 @@
 import { Sighting } from '../models/sighting';
 import { Vehicle } from '../models/vehicle';
-import { escapeMarkdown, Guild, User } from 'discord.js';
+import { escapeMarkdown, User } from 'discord.js';
 import { DateTime } from '../util/date-time';
 import { DiscordTimestamps } from '../enums/discord-timestamps';
 import { Str } from '../util/str';
@@ -173,14 +173,14 @@ export class Sightings {
         author: User,
         interactionId: string,
         channelId: string | null,
-        guild: Guild | null,
+        discordGuildId: string | null,
         comment: null | string = null,
         vehicleId: number | null
     ): void {
         Sighting.create({
             license,
             discordUserId: author.id,
-            discordGuildId: guild?.id,
+            discordGuildId: discordGuildId ?? undefined,
             discordChannelId: channelId ?? undefined,
             discordInteractionId: interactionId,
             comment: comment ? Str.limitCharacters(escapeMarkdown(comment), 255) : null,

--- a/src/types/license-view.ts
+++ b/src/types/license-view.ts
@@ -1,0 +1,21 @@
+import { VehicleInfo } from '../models/vehicle-info';
+import { FuelInfo } from '../models/fuel-info';
+
+export interface LicenseViewData {
+    vehicleInfo: VehicleInfo;
+    fuelInfo: FuelInfo;
+    formattedLicense: string;
+    vehicleType: string | null;
+    badge: string | null;
+    comment: string | null;
+    sightingsList: string | null;
+    spotCount: number | null;
+}
+
+export interface NorwegianViewData {
+    license: string;
+    brand: string;
+    model: string;
+    fuelDescription: string;
+    registeredTimestamp: number;
+}

--- a/src/util/dutch-plate.ts
+++ b/src/util/dutch-plate.ts
@@ -1,11 +1,23 @@
 export class DutchPlate {
     private static readonly ESC = '\u001b';
+    private static readonly STRIP_WIDTH = 4;
+    private static readonly PLATE_PADDING = 2;
 
     public static render(formattedLicense: string): string {
         const blueStrip = `${this.ESC}[0;37;44m`;
+        const blueStripBold = `${this.ESC}[1;37;44m`;
         const yellowPlate = `${this.ESC}[0;30;43m`;
+        const yellowPlateBold = `${this.ESC}[1;30;43m`;
         const reset = `${this.ESC}[0m`;
 
-        return `\`\`\`ansi\n${blueStrip}NL${yellowPlate} ${formattedLicense} ${reset}\n\`\`\``;
+        const plateWidth = formattedLicense.length + this.PLATE_PADDING * 2;
+        const stripBlank = ' '.repeat(this.STRIP_WIDTH);
+        const plateBlank = ' '.repeat(plateWidth);
+        const platePadding = ' '.repeat(this.PLATE_PADDING);
+
+        const paddingRow = `${blueStrip}${stripBlank}${yellowPlate}${plateBlank}${reset}`;
+        const plateRow = `${blueStripBold} NL ${yellowPlateBold}${platePadding}${formattedLicense}${platePadding}${reset}`;
+
+        return `\`\`\`ansi\n${paddingRow}\n${plateRow}\n${paddingRow}\n\`\`\``;
     }
 }

--- a/src/util/dutch-plate.ts
+++ b/src/util/dutch-plate.ts
@@ -1,23 +1,14 @@
 export class DutchPlate {
     private static readonly ESC = '\u001b';
-    private static readonly STRIP_WIDTH = 4;
     private static readonly PLATE_PADDING = 2;
 
     public static render(formattedLicense: string): string {
-        const blueStrip = `${this.ESC}[0;37;44m`;
-        const blueStripBold = `${this.ESC}[1;37;44m`;
-        const yellowPlate = `${this.ESC}[0;30;43m`;
-        const yellowPlateBold = `${this.ESC}[1;30;43m`;
+        const blueStrip = `${this.ESC}[1;37;44m`;
+        const yellowPlate = `${this.ESC}[1;30;43m`;
         const reset = `${this.ESC}[0m`;
 
-        const plateWidth = formattedLicense.length + this.PLATE_PADDING * 2;
-        const stripBlank = ' '.repeat(this.STRIP_WIDTH);
-        const plateBlank = ' '.repeat(plateWidth);
-        const platePadding = ' '.repeat(this.PLATE_PADDING);
+        const padding = ' '.repeat(this.PLATE_PADDING);
 
-        const paddingRow = `${blueStrip}${stripBlank}${yellowPlate}${plateBlank}${reset}`;
-        const plateRow = `${blueStripBold} NL ${yellowPlateBold}${platePadding}${formattedLicense}${platePadding}${reset}`;
-
-        return `\`\`\`ansi\n${paddingRow}\n${plateRow}\n${paddingRow}\n\`\`\``;
+        return `\`\`\`ansi\n${blueStrip} NL ${yellowPlate}${padding}${formattedLicense}${padding}${reset}\n\`\`\``;
     }
 }

--- a/src/util/dutch-plate.ts
+++ b/src/util/dutch-plate.ts
@@ -1,0 +1,11 @@
+export class DutchPlate {
+    private static readonly ESC = '\u001b';
+
+    public static render(formattedLicense: string): string {
+        const blueStrip = `${this.ESC}[0;37;44m`;
+        const yellowPlate = `${this.ESC}[0;30;43m`;
+        const reset = `${this.ESC}[0m`;
+
+        return `\`\`\`ansi\n${blueStrip}NL${yellowPlate} ${formattedLicense} ${reset}\n\`\`\``;
+    }
+}

--- a/src/util/first-spot-badge.ts
+++ b/src/util/first-spot-badge.ts
@@ -1,0 +1,9 @@
+import { Str } from './str';
+
+export class FirstSpotBadge {
+    public static message(brand: string, tradeName: string): string {
+        const name = `${Str.toTitleCase(brand)} ${Str.toTitleCase(tradeName)}`.trim();
+
+        return `Niemand in deze server had de **${name}** al gespot!`;
+    }
+}

--- a/src/util/first-spot-badge.ts
+++ b/src/util/first-spot-badge.ts
@@ -4,6 +4,6 @@ export class FirstSpotBadge {
     public static message(brand: string, tradeName: string): string {
         const name = `${Str.toTitleCase(brand)} ${Str.toTitleCase(tradeName)}`.trim();
 
-        return `Niemand in deze server had de **${name}** al gespot!`;
+        return `Je bent de eerste in de server die een **${name}** heeft gespot!`;
     }
 }

--- a/src/util/license-view.ts
+++ b/src/util/license-view.ts
@@ -11,6 +11,7 @@ import {
 } from 'discord.js';
 import { LicenseViewData, NorwegianViewData } from '../types/license-view';
 import { VehicleInfo } from '../models/vehicle-info';
+import { DutchPlate } from './dutch-plate';
 import { Str } from './str';
 import { DateTime } from './date-time';
 import { DiscordTimestamps } from '../enums/discord-timestamps';
@@ -25,16 +26,10 @@ export class LicenseView {
     public static build(data: LicenseViewData, now = Date.now()): ContainerBuilder[] {
         const container = new ContainerBuilder().setAccentColor(this.accentColor(data));
 
-        this.addHeader(container, data);
-
         const specs = this.buildSpecs(data, now);
+        this.addHeader(container, data, specs);
+
         const flags = this.buildFlags(data.vehicleInfo);
-        if (specs || flags.length > 0) {
-            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
-        }
-        if (specs) {
-            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(specs));
-        }
         if (flags.length > 0) {
             container.addTextDisplayComponents(new TextDisplayBuilder().setContent(flags.join('\n')));
         }
@@ -124,7 +119,7 @@ export class LicenseView {
         return [container];
     }
 
-    private static addHeader(container: ContainerBuilder, data: LicenseViewData): void {
+    private static addHeader(container: ContainerBuilder, data: LicenseViewData, specs: string | null): void {
         const vehicleInfo = data.vehicleInfo;
 
         const nameParts: string[] = [];
@@ -136,20 +131,31 @@ export class LicenseView {
         }
 
         const title = `## ${nameParts.length > 0 ? nameParts.join(' ') : data.formattedLicense}`;
-        const subtitle = data.vehicleType
-            ? `\`${data.formattedLicense}\` · ${data.vehicleType}`
-            : `\`${data.formattedLicense}\``;
+
+        const headerParts = [title, DutchPlate.render(data.formattedLicense)];
+        if (data.vehicleType) {
+            headerParts.push(`-# ${data.vehicleType}`);
+        }
+        const header = headerParts.join('\n');
 
         if (vehicleInfo.merk) {
-            container.addSectionComponents(
-                new SectionBuilder()
-                    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n${subtitle}`))
-                    .setThumbnailAccessory(new ThumbnailBuilder().setURL(this.logoUrl(vehicleInfo.merk)))
-            );
+            const section = new SectionBuilder()
+                .addTextDisplayComponents(new TextDisplayBuilder().setContent(header))
+                .setThumbnailAccessory(new ThumbnailBuilder().setURL(this.logoUrl(vehicleInfo.merk)));
+
+            if (specs) {
+                section.addTextDisplayComponents(new TextDisplayBuilder().setContent(specs));
+            }
+
+            container.addSectionComponents(section);
             return;
         }
 
-        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n${subtitle}`));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(header));
+
+        if (specs) {
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(specs));
+        }
     }
 
     private static buildSpecs(data: LicenseViewData, now: number): string | null {

--- a/src/util/license-view.ts
+++ b/src/util/license-view.ts
@@ -1,0 +1,305 @@
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    ContainerBuilder,
+    SectionBuilder,
+    SeparatorBuilder,
+    SeparatorSpacingSize,
+    TextDisplayBuilder,
+    ThumbnailBuilder,
+} from 'discord.js';
+import { LicenseViewData, NorwegianViewData } from '../types/license-view';
+import { VehicleInfo } from '../models/vehicle-info';
+import { Str } from './str';
+import { DateTime } from './date-time';
+import { DiscordTimestamps } from '../enums/discord-timestamps';
+
+export class LicenseView {
+    private static readonly ACCENT_DEFAULT = 0x5865f2;
+    private static readonly ACCENT_ELECTRIC = 0x57f287;
+    private static readonly ACCENT_DIESEL = 0x4e5058;
+    private static readonly APK_WARNING_WINDOW_MS = 1000 * 60 * 60 * 24 * 60;
+    private static readonly IMPORT_THRESHOLD_MS = 1000 * 60 * 60 * 24 * 180;
+
+    public static build(data: LicenseViewData, now = Date.now()): ContainerBuilder[] {
+        const container = new ContainerBuilder().setAccentColor(this.accentColor(data));
+
+        this.addHeader(container, data);
+
+        const specs = this.buildSpecs(data, now);
+        const flags = this.buildFlags(data.vehicleInfo);
+        if (specs || flags.length > 0) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+        }
+        if (specs) {
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(specs));
+        }
+        if (flags.length > 0) {
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(flags.join('\n')));
+        }
+
+        const notes: string[] = [];
+        if (data.badge) {
+            notes.push(`🥇 ${data.badge}`);
+        }
+        if (data.comment) {
+            notes.push(`💬 _${data.comment}_`);
+        }
+        if (notes.length > 0) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(notes.join('\n')));
+        }
+
+        if (data.sightingsList) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+            container.addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(`**Eerder gespot door**\n${data.sightingsList}`)
+            );
+        }
+
+        container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(this.buildFooter(data)));
+
+        container.addActionRowComponents(this.buildLinks(data.vehicleInfo.kenteken));
+
+        return [container];
+    }
+
+    public static buildNotFound(license: string, formattedLicense: string, sightingsList: string): ContainerBuilder[] {
+        const container = new ContainerBuilder().setAccentColor(this.ACCENT_DEFAULT);
+
+        container.addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(`## Kenteken ${license} niet gevonden, rdw heeft m niet meer (rip)`)
+        );
+        container.addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(`**Eerder gespot door**\n${sightingsList}`)
+        );
+
+        if (formattedLicense) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${formattedLicense}`));
+        }
+
+        return [container];
+    }
+
+    public static buildNorwegian(data: NorwegianViewData): ContainerBuilder[] {
+        const container = new ContainerBuilder().setAccentColor(this.ACCENT_DEFAULT);
+
+        const nameParts: string[] = [];
+        if (data.brand) {
+            nameParts.push(Str.toTitleCase(data.brand));
+        }
+        if (data.model) {
+            nameParts.push(Str.toTitleCase(data.model));
+        }
+        const title = `## ${nameParts.length > 0 ? nameParts.join(' ') : data.license}`;
+
+        if (data.brand) {
+            container.addSectionComponents(
+                new SectionBuilder()
+                    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n\`${data.license}\``))
+                    .setThumbnailAccessory(new ThumbnailBuilder().setURL(this.logoUrl(data.brand)))
+            );
+        } else {
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n\`${data.license}\``));
+        }
+
+        const specs: string[] = [];
+        if (data.fuelDescription) {
+            specs.push(data.fuelDescription);
+        }
+        if (data.registeredTimestamp) {
+            specs.push(`🗓️ ${DateTime.getDiscordTimestamp(data.registeredTimestamp, DiscordTimestamps.SHORT_DATE)}`);
+        }
+        if (specs.length > 0) {
+            container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(specs.join('\n')));
+        }
+
+        container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# 🇳🇴 ${data.license}`));
+
+        return [container];
+    }
+
+    private static addHeader(container: ContainerBuilder, data: LicenseViewData): void {
+        const vehicleInfo = data.vehicleInfo;
+
+        const nameParts: string[] = [];
+        if (vehicleInfo.merk) {
+            nameParts.push(Str.toTitleCase(vehicleInfo.merk));
+        }
+        if (vehicleInfo.handelsbenaming.trim()) {
+            nameParts.push(Str.toTitleCase(vehicleInfo.handelsbenaming.trim()));
+        }
+
+        const title = `## ${nameParts.length > 0 ? nameParts.join(' ') : data.formattedLicense}`;
+        const subtitle = data.vehicleType
+            ? `\`${data.formattedLicense}\` · ${data.vehicleType}`
+            : `\`${data.formattedLicense}\``;
+
+        if (vehicleInfo.merk) {
+            container.addSectionComponents(
+                new SectionBuilder()
+                    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n${subtitle}`))
+                    .setThumbnailAccessory(new ThumbnailBuilder().setURL(this.logoUrl(vehicleInfo.merk)))
+            );
+            return;
+        }
+
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`${title}\n${subtitle}`));
+    }
+
+    private static buildSpecs(data: LicenseViewData, now: number): string | null {
+        const vehicleInfo = data.vehicleInfo;
+
+        const firstLine: string[] = [];
+        for (const engine of data.fuelInfo.engines) {
+            if (engine.getHorsePower()) {
+                firstLine.push(engine.getHorsePowerDescription());
+            }
+        }
+        if (vehicleInfo.eerste_kleur) {
+            firstLine.push(`🎨 ${Str.toTitleCase(vehicleInfo.eerste_kleur)}`);
+        }
+        if (vehicleInfo.getPrice()) {
+            firstLine.push(vehicleInfo.getPriceDescription());
+        }
+
+        const secondLine: string[] = [];
+        const constructionTimestamp = vehicleInfo.getConstructionDateTimestamp();
+        if (!isNaN(constructionTimestamp)) {
+            const constructionDate = DateTime.getDiscordTimestamp(constructionTimestamp, DiscordTimestamps.SHORT_DATE);
+            secondLine.push(`🗓️ ${constructionDate} (${this.age(constructionTimestamp, now)})`);
+        }
+
+        const apk = this.apkDescription(vehicleInfo, now);
+        if (apk) {
+            secondLine.push(apk);
+        }
+
+        const lines: string[] = [];
+        if (firstLine.length > 0) {
+            lines.push(firstLine.join(' · '));
+        }
+        if (secondLine.length > 0) {
+            lines.push(secondLine.join(' · '));
+        }
+
+        return lines.length > 0 ? lines.join('\n') : null;
+    }
+
+    private static apkDescription(vehicleInfo: VehicleInfo, now: number): string | null {
+        const expiry = vehicleInfo.getApkExpiryTimestamp();
+        if (!expiry) {
+            return null;
+        }
+
+        if (expiry < now) {
+            return `⚠️ APK verlopen ${DateTime.getDiscordTimestamp(expiry, DiscordTimestamps.RELATIVE)}`;
+        }
+
+        if (expiry - now < this.APK_WARNING_WINDOW_MS) {
+            return `⚠️ APK verloopt ${DateTime.getDiscordTimestamp(expiry, DiscordTimestamps.RELATIVE)}`;
+        }
+
+        return `🔧 APK tot ${DateTime.getDiscordTimestamp(expiry, DiscordTimestamps.SHORT_DATE)}`;
+    }
+
+    private static buildFlags(vehicleInfo: VehicleInfo): string[] {
+        const flags: string[] = [];
+
+        if (vehicleInfo.openstaande_terugroepactie_indicator === 'Ja') {
+            flags.push('⚠️ Openstaande terugroepactie');
+        }
+
+        if (vehicleInfo.wam_verzekerd === 'Nee') {
+            flags.push('🛑 Niet WAM-verzekerd');
+        }
+
+        if (vehicleInfo.tellerstandoordeel === 'Onlogisch') {
+            flags.push('📉 Onlogische tellerstand');
+        }
+
+        if (vehicleInfo.taxi_indicator === 'Ja') {
+            flags.push('🚕 Taxiverleden');
+        }
+
+        if (vehicleInfo.export_indicator === 'Ja') {
+            flags.push('📤 Geëxporteerd');
+        }
+
+        if (this.isImported(vehicleInfo)) {
+            flags.push('📦 Geïmporteerd');
+        }
+
+        return flags;
+    }
+
+    private static isImported(vehicleInfo: VehicleInfo): boolean {
+        const firstRegistrationNl = vehicleInfo.getFirstRegistrationInNetherlandsTimestamp();
+        const constructionTimestamp = vehicleInfo.getConstructionDateTimestamp();
+
+        if (!firstRegistrationNl || isNaN(constructionTimestamp)) {
+            return false;
+        }
+
+        return firstRegistrationNl - constructionTimestamp > this.IMPORT_THRESHOLD_MS;
+    }
+
+    private static age(constructionTimestamp: number, now: number): string {
+        const months = Math.floor((now - constructionTimestamp) / (1000 * 60 * 60 * 24 * 30.44));
+
+        if (months < 1) {
+            return 'nieuw';
+        }
+
+        if (months < 12) {
+            return `${months} ${months === 1 ? 'maand' : 'maanden'}`;
+        }
+
+        const years = Math.floor(months / 12);
+        return `${years} jaar`;
+    }
+
+    private static accentColor(data: LicenseViewData): number {
+        const fuel = data.fuelInfo.engines[0]?.brandstof_omschrijving?.toLowerCase();
+
+        if (fuel === 'elektriciteit') {
+            return this.ACCENT_ELECTRIC;
+        }
+
+        if (fuel === 'diesel') {
+            return this.ACCENT_DIESEL;
+        }
+
+        return this.ACCENT_DEFAULT;
+    }
+
+    private static buildFooter(data: LicenseViewData): string {
+        if (data.spotCount && data.spotCount > 0) {
+            return `-# ${data.spotCount}× gespot in deze server`;
+        }
+
+        return `-# ${data.formattedLicense}`;
+    }
+
+    private static buildLinks(license: string): ActionRowBuilder<ButtonBuilder> {
+        return new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setLabel('Kentekencheck')
+                .setStyle(ButtonStyle.Link)
+                .setURL(`https://kentekencheck.nl/kenteken?i=${license}`),
+            new ButtonBuilder()
+                .setLabel('Finnik')
+                .setStyle(ButtonStyle.Link)
+                .setURL(`https://finnik.nl/kenteken/${license}/gratis`)
+        );
+    }
+
+    private static logoUrl(brand: string): string {
+        return `https://www.kentekencheck.nl/assets/img/brands/${Str.humanToSnakeCase(brand)}.png`;
+    }
+}

--- a/tests/util/dutch-plate.spec.ts
+++ b/tests/util/dutch-plate.spec.ts
@@ -1,0 +1,13 @@
+import { DutchPlate } from '../../src/util/dutch-plate';
+
+describe('DutchPlate.render', () => {
+    it('renders the plate as an ansi block with blue NL strip and yellow plate', () => {
+        const plate = DutchPlate.render('X-897-PL');
+
+        expect(plate.startsWith('```ansi\n')).toBe(true);
+        expect(plate.endsWith('\n```')).toBe(true);
+        expect(plate).toContain('[0;37;44mNL');
+        expect(plate).toContain('[0;30;43m X-897-PL ');
+        expect(plate).toContain('[0m');
+    });
+});

--- a/tests/util/dutch-plate.spec.ts
+++ b/tests/util/dutch-plate.spec.ts
@@ -6,8 +6,16 @@ describe('DutchPlate.render', () => {
 
         expect(plate.startsWith('```ansi\n')).toBe(true);
         expect(plate.endsWith('\n```')).toBe(true);
-        expect(plate).toContain('[0;37;44mNL');
-        expect(plate).toContain('[0;30;43m X-897-PL ');
-        expect(plate).toContain('[0m');
+        expect(plate).toContain('[1;37;44m NL ');
+        expect(plate).toContain('[1;30;43m  X-897-PL  ');
+    });
+
+    it('pads the plate with matching-width blank rows above and below', () => {
+        const plate = DutchPlate.render('X-897-PL');
+        const rows = plate.split('\n').slice(1, -1);
+
+        expect(rows).toHaveLength(3);
+        expect(rows[0]).toBe(rows[2]);
+        expect(rows[0]).toContain(' '.repeat('X-897-PL'.length + 4));
     });
 });

--- a/tests/util/dutch-plate.spec.ts
+++ b/tests/util/dutch-plate.spec.ts
@@ -1,21 +1,15 @@
 import { DutchPlate } from '../../src/util/dutch-plate';
 
 describe('DutchPlate.render', () => {
-    it('renders the plate as an ansi block with blue NL strip and yellow plate', () => {
+    it('renders a single bold row with blue NL strip and yellow plate', () => {
         const plate = DutchPlate.render('X-897-PL');
 
         expect(plate.startsWith('```ansi\n')).toBe(true);
         expect(plate.endsWith('\n```')).toBe(true);
         expect(plate).toContain('[1;37;44m NL ');
         expect(plate).toContain('[1;30;43m  X-897-PL  ');
-    });
 
-    it('pads the plate with matching-width blank rows above and below', () => {
-        const plate = DutchPlate.render('X-897-PL');
         const rows = plate.split('\n').slice(1, -1);
-
-        expect(rows).toHaveLength(3);
-        expect(rows[0]).toBe(rows[2]);
-        expect(rows[0]).toContain(' '.repeat('X-897-PL'.length + 4));
+        expect(rows).toHaveLength(1);
     });
 });

--- a/tests/util/first-spot-badge.spec.ts
+++ b/tests/util/first-spot-badge.spec.ts
@@ -1,0 +1,13 @@
+import { FirstSpotBadge } from '../../src/util/first-spot-badge';
+
+describe('FirstSpotBadge.message', () => {
+    it('title-cases the brand and model', () => {
+        expect(FirstSpotBadge.message('VOLKSWAGEN', 'GOLF')).toBe(
+            'Niemand in deze server had de **Volkswagen Golf** al gespot!'
+        );
+    });
+
+    it('trims a trailing space when the model is empty', () => {
+        expect(FirstSpotBadge.message('TESLA', '')).toBe('Niemand in deze server had de **Tesla** al gespot!');
+    });
+});

--- a/tests/util/first-spot-badge.spec.ts
+++ b/tests/util/first-spot-badge.spec.ts
@@ -3,11 +3,13 @@ import { FirstSpotBadge } from '../../src/util/first-spot-badge';
 describe('FirstSpotBadge.message', () => {
     it('title-cases the brand and model', () => {
         expect(FirstSpotBadge.message('VOLKSWAGEN', 'GOLF')).toBe(
-            'Niemand in deze server had de **Volkswagen Golf** al gespot!'
+            'Je bent de eerste in de server die een **Volkswagen Golf** heeft gespot!'
         );
     });
 
     it('trims a trailing space when the model is empty', () => {
-        expect(FirstSpotBadge.message('TESLA', '')).toBe('Niemand in deze server had de **Tesla** al gespot!');
+        expect(FirstSpotBadge.message('TESLA', '')).toBe(
+            'Je bent de eerste in de server die een **Tesla** heeft gespot!'
+        );
     });
 });

--- a/tests/util/license-view.spec.ts
+++ b/tests/util/license-view.spec.ts
@@ -70,11 +70,12 @@ function viewData(overrides: Partial<LicenseViewData> = {}): LicenseViewData {
 }
 
 describe('LicenseView.build', () => {
-    it('renders the header with brand, model and plate', () => {
+    it('renders the header with brand, model and the plate as a dutch plate block', () => {
         const contents = textContents(LicenseView.build(viewData(), NOW));
 
         expect(contents).toContain('## Opel Corsa');
-        expect(contents).toContain('`X-897-PL`');
+        expect(contents).toContain('```ansi');
+        expect(contents).toContain(' X-897-PL ');
     });
 
     it('renders specs with power, colour, price, age and apk', () => {

--- a/tests/util/license-view.spec.ts
+++ b/tests/util/license-view.spec.ts
@@ -1,0 +1,227 @@
+import { LicenseView } from '../../src/util/license-view';
+import { LicenseViewData } from '../../src/types/license-view';
+import { VehicleInfo } from '../../src/models/vehicle-info';
+import { FuelInfo } from '../../src/models/fuel-info';
+import { EngineInfo } from '../../src/models/engine-info';
+
+const NOW = new Date('2026-07-10T12:00:00Z').getTime();
+
+function textContents(containers: ReturnType<typeof LicenseView.build>): string {
+    const contents: string[] = [];
+
+    for (const container of containers) {
+        for (const component of container.toJSON().components) {
+            if ('content' in component && typeof component.content === 'string') {
+                contents.push(component.content);
+            }
+            if ('components' in component && Array.isArray(component.components)) {
+                for (const child of component.components) {
+                    if ('content' in child && typeof child.content === 'string') {
+                        contents.push(child.content);
+                    }
+                }
+            }
+        }
+    }
+
+    return contents.join('\n');
+}
+
+function vehicleInfo(overrides: Record<string, unknown> = {}): VehicleInfo {
+    return new VehicleInfo({
+        kenteken: 'X897PL',
+        merk: 'OPEL',
+        handelsbenaming: 'CORSA',
+        eerste_kleur: 'GRIJS',
+        catalogusprijs: '27247',
+        datum_eerste_toelating: '20240119',
+        datum_eerste_toelating_dt: '2024-01-19T00:00:00.000',
+        datum_eerste_tenaamstelling_in_nederland_dt: '2024-01-19T00:00:00.000',
+        vervaldatum_apk_dt: '2028-01-19T00:00:00.000',
+        openstaande_terugroepactie_indicator: 'Nee',
+        wam_verzekerd: 'Ja',
+        tellerstandoordeel: 'Logisch',
+        taxi_indicator: 'Nee',
+        export_indicator: 'Nee',
+        ...overrides,
+    });
+}
+
+function fuelInfo(engines: Record<string, unknown>[]): FuelInfo {
+    const info = new FuelInfo();
+    for (const engine of engines) {
+        info.engines.push(new EngineInfo(engine));
+    }
+    return info;
+}
+
+function viewData(overrides: Partial<LicenseViewData> = {}): LicenseViewData {
+    return {
+        vehicleInfo: vehicleInfo(),
+        fuelInfo: fuelInfo([{ nettomaximumvermogen: '74', brandstof_omschrijving: 'Benzine' }]),
+        formattedLicense: 'X-897-PL',
+        vehicleType: null,
+        badge: null,
+        comment: null,
+        sightingsList: null,
+        spotCount: null,
+        ...overrides,
+    };
+}
+
+describe('LicenseView.build', () => {
+    it('renders the header with brand, model and plate', () => {
+        const contents = textContents(LicenseView.build(viewData(), NOW));
+
+        expect(contents).toContain('## Opel Corsa');
+        expect(contents).toContain('`X-897-PL`');
+    });
+
+    it('renders specs with power, colour, price, age and apk', () => {
+        const contents = textContents(LicenseView.build(viewData(), NOW));
+
+        expect(contents).toContain('⛽ 101PK');
+        expect(contents).toContain('🎨 Grijs');
+        expect(contents).toContain('💵');
+        expect(contents).toContain('(2 jaar)');
+        expect(contents).toContain('🔧 APK tot');
+    });
+
+    it('skips missing fields instead of showing placeholders', () => {
+        const data = viewData({
+            vehicleInfo: vehicleInfo({
+                eerste_kleur: '',
+                catalogusprijs: '',
+                vervaldatum_apk_dt: '',
+                datum_eerste_toelating: '',
+            }),
+            fuelInfo: fuelInfo([]),
+        });
+
+        const contents = textContents(LicenseView.build(data, NOW));
+
+        expect(contents).not.toContain('🎨');
+        expect(contents).not.toContain('💵');
+        expect(contents).not.toContain('Onbekend');
+        expect(contents).not.toContain('APK');
+        expect(contents).not.toContain('🗓️');
+        expect(contents).toContain('## Opel Corsa');
+    });
+
+    it('shows both engines of a hybrid', () => {
+        const data = viewData({
+            fuelInfo: fuelInfo([
+                { nettomaximumvermogen: '74', brandstof_omschrijving: 'Benzine' },
+                { netto_max_vermogen_elektrisch: '50', brandstof_omschrijving: 'Elektriciteit' },
+            ]),
+        });
+
+        const contents = textContents(LicenseView.build(data, NOW));
+
+        expect(contents).toContain('⛽ 101PK');
+        expect(contents).toContain('⚡ 68PK');
+    });
+
+    it('falls back to the plate as title when brand and model are missing', () => {
+        const data = viewData({ vehicleInfo: vehicleInfo({ merk: '', handelsbenaming: '' }) });
+
+        const contents = textContents(LicenseView.build(data, NOW));
+
+        expect(contents).toContain('## X-897-PL');
+    });
+
+    it('warns when the apk has expired', () => {
+        const data = viewData({ vehicleInfo: vehicleInfo({ vervaldatum_apk_dt: '2025-01-19T00:00:00.000' }) });
+
+        const contents = textContents(LicenseView.build(data, NOW));
+
+        expect(contents).toContain('⚠️ APK verlopen');
+    });
+
+    it('shows status flags only when applicable', () => {
+        const clean = textContents(LicenseView.build(viewData(), NOW));
+        expect(clean).not.toContain('terugroepactie');
+        expect(clean).not.toContain('WAM');
+        expect(clean).not.toContain('tellerstand');
+
+        const flagged = viewData({
+            vehicleInfo: vehicleInfo({
+                openstaande_terugroepactie_indicator: 'Ja',
+                wam_verzekerd: 'Nee',
+                tellerstandoordeel: 'Onlogisch',
+            }),
+        });
+        const contents = textContents(LicenseView.build(flagged, NOW));
+
+        expect(contents).toContain('⚠️ Openstaande terugroepactie');
+        expect(contents).toContain('🛑 Niet WAM-verzekerd');
+        expect(contents).toContain('📉 Onlogische tellerstand');
+    });
+
+    it('flags imports when the first registration in NL is much later', () => {
+        const data = viewData({
+            vehicleInfo: vehicleInfo({
+                datum_eerste_tenaamstelling_in_nederland_dt: '2026-01-19T00:00:00.000',
+            }),
+        });
+
+        expect(textContents(LicenseView.build(data, NOW))).toContain('📦 Geïmporteerd');
+    });
+
+    it('renders badge, comment, sightings and spot count', () => {
+        const data = viewData({
+            badge: 'Je bent de eerste!',
+            comment: 'mooie kar',
+            sightingsList: '<@user-1> - 2 maanden geleden',
+            spotCount: 3,
+        });
+
+        const contents = textContents(LicenseView.build(data, NOW));
+
+        expect(contents).toContain('🥇 Je bent de eerste!');
+        expect(contents).toContain('💬 _mooie kar_');
+        expect(contents).toContain('**Eerder gespot door**');
+        expect(contents).toContain('-# 3× gespot in deze server');
+    });
+
+    it('uses an accent colour based on the primary fuel type', () => {
+        const electric = viewData({
+            fuelInfo: fuelInfo([{ netto_max_vermogen_elektrisch: '150', brandstof_omschrijving: 'Elektriciteit' }]),
+        });
+        const diesel = viewData({
+            fuelInfo: fuelInfo([{ nettomaximumvermogen: '100', brandstof_omschrijving: 'Diesel' }]),
+        });
+
+        expect(LicenseView.build(electric, NOW)[0].toJSON().accent_color).toBe(0x57f287);
+        expect(LicenseView.build(diesel, NOW)[0].toJSON().accent_color).toBe(0x4e5058);
+        expect(LicenseView.build(viewData(), NOW)[0].toJSON().accent_color).toBe(0x5865f2);
+    });
+});
+
+describe('LicenseView.buildNotFound', () => {
+    it('renders the not-found message with the sightings list', () => {
+        const contents = textContents(LicenseView.buildNotFound('X897PL', 'X-897-PL', '<@user-1> - gisteren'));
+
+        expect(contents).toContain('niet gevonden');
+        expect(contents).toContain('**Eerder gespot door**');
+        expect(contents).toContain('-# X-897-PL');
+    });
+});
+
+describe('LicenseView.buildNorwegian', () => {
+    it('renders the norwegian vehicle with flag footer', () => {
+        const contents = textContents(
+            LicenseView.buildNorwegian({
+                license: 'AB12345',
+                brand: 'VOLVO',
+                model: 'XC90',
+                fuelDescription: '⚡ 408PK',
+                registeredTimestamp: NOW,
+            })
+        );
+
+        expect(contents).toContain('## Volvo Xc90');
+        expect(contents).toContain('⚡ 408PK');
+        expect(contents).toContain('-# 🇳🇴 AB12345');
+    });
+});


### PR DESCRIPTION
## What

Rebuilds the `/k` reply as a **Components V2 container** — nicer layout and more useful info, all from data the bot already fetches.

```
┌──────────────────────────────────────────
│ ## Opel Corsa                    [logo]
│ `X-897-PL` · Personenauto
│ ─────────────────────────
│ ⛽ 101PK · 🎨 Grijs · 💵 € 27.247
│ 🗓️ 19/01/2024 (2 jaar) · 🔧 APK tot 19/01/2028
│ 📉 Onlogische tellerstand          ← only when applicable
│ ─────────────────────────
│ 🥇 Je bent de eerste in de server die een Opel Corsa heeft gespot!
│ 💬 _lelijke kleur_
│ ─────────────────────────
│ **Eerder gespot door**
│ @Kef — 2 maanden geleden
│ ─────────────────────────
│ -# 3× gespot in deze server
│ [Kentekencheck] [Finnik]
└──────────────────────────────────────────
```

### New info
- **🔧 APK-vervaldatum** — with ⚠️ when expired or expiring within 60 days
- **Status flags**, shown *only* when something's up: ⚠️ open recall · 🛑 not WAM-insured · 📉 illogical odometer · 🚕 taxi history · 📤 exported · 📦 imported (first NL registration ≫ construction date)
- **Age** next to the construction date (`(2 jaar)` / `(11 maanden)` / `(nieuw)`)
- **Accent colour by fuel type**: ⚡ green for EVs, grey for diesel, blurple otherwise
- **Spot counter** in the footer: `3× gespot in deze server`

### Built flexibly
Many RDW records miss fields — the view skips anything absent instead of printing placeholders ("Onbekende catalogusprijs" is gone). Hybrids show every engine (`⛽ 101PK · ⚡ 68PK`). No brand/model → the plate becomes the title. The not-found and Norwegian 🇳🇴 replies use the same CV2 layout.

## Implementation

- `util/license-view.ts` — all rendering (main, not-found, Norwegian), pure and unit-tested; takes an injectable `now` for deterministic tests
- `types/license-view.ts` — view input shapes
- `models/vehicle-info.ts` — adds `vervaldatum_apk_dt` + timestamp getters
- `services/sightings.ts` — `countForLicense` for the footer counter
- `commands/license.ts` — slims down to fetching + composing

> ⚠️ **Depends on #125 and #130** (branch includes both): the primeur badge is rendered inside the new layout, and the guild-id fix makes the spot counter correct. Merge those first. Conflicts with #122 (autocomplete) are limited to imports.

## Testing

- 12 new unit tests: full render, missing-fields render, hybrid engines, plate-fallback title, APK expiry warning, conditional flags, import detection, badge/comment/counter, fuel accent colours, not-found and Norwegian views.
- Field availability verified against a live RDW response (WOK is not in open data, so that flag was deliberately left out).
- `npm run build`, `npm run lint`, `npm test` all green (79 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)