### PR TITLE
Fix the leaderboard stats button and list /k spotters with their last spot

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -136,14 +136,21 @@ export class Bot {
             return;
         }
 
-        const view = customId.split(':')[1];
+        const [, view, contextUserId] = customId.split(':');
         if (!isBoardView(view)) {
             return;
         }
 
         await interaction.deferUpdate();
 
-        const components = await Boards.render(view, interaction.guildId, interaction.user);
+        // Older messages carry no user id in the button; only then does the
+        // presser become the subject of the boards.
+        const user =
+            contextUserId && contextUserId !== interaction.user.id
+                ? await this.client.users.fetch(contextUserId)
+                : interaction.user;
+
+        const components = await Boards.render(view, interaction.guildId, user);
 
         await interaction.editReply({
             components,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -21,8 +21,6 @@ export class Bot {
     public async liftOff(): Promise<void> {
         await Promise.all([this.login(), await CommandCollection.getInstance().register()]);
 
-        this.startHeartbeat();
-
         this.client.on('clientReady', () => {
             Output.line(`Logged in as ${this.client.user?.tag}`);
             this.client.user?.setActivity(`/k <kenteken>`);
@@ -37,6 +35,10 @@ export class Bot {
                 Output.error(`Interaction ${interaction.id} failed`, error);
             });
         });
+
+        // Started last: a broken heartbeat endpoint must never cost the bot its
+        // interaction listeners.
+        this.startHeartbeat();
     }
 
     private startHeartbeat(): void {

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -74,11 +74,10 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
-        const [vehicleInfo, fuelInfo, sightings, previousSpotCount] = await Promise.all([
+        const [vehicleInfo, fuelInfo, sightings] = await Promise.all([
             VehicleInfo.get(license),
             FuelInfo.get(license),
             Sightings.summary(license, this.interaction.guildId, this.interaction.user.id),
-            Sightings.countForLicense(license, this.interaction.guildId),
         ]);
 
         if (!vehicleInfo) {
@@ -106,7 +105,6 @@ export class License extends BaseCommand implements ICommand {
             badge: isFirstModel ? FirstSpotBadge.message(vehicleInfo.merk, vehicleInfo.handelsbenaming) : null,
             comment: this.getComment(),
             sightings,
-            spotCount: previousSpotCount !== null ? previousSpotCount + 1 : null,
             logo: await BrandLogo.resolve(vehicleInfo.merk),
         });
 

--- a/src/queries/sightings.ts
+++ b/src/queries/sightings.ts
@@ -93,14 +93,6 @@ export class Sightings {
         return { brand, tradeName, color, totalHorsepower, primaryFuelType, country };
     }
 
-    public static async countForLicense(license: string, discordGuildId: string | null): Promise<number | null> {
-        if (!discordGuildId) {
-            return null;
-        }
-
-        return Sighting.count({ where: { license, discordGuildId } });
-    }
-
     // A summary instead of a row per sighting: a car spotted forty times produced
     // forty near-identical lines, which pushed the rest of the reply off screen. The
     // rows are read in full because the counts are per spotter.
@@ -120,21 +112,30 @@ export class Sightings {
             return null;
         }
 
-        const counts = new Map<string, number>();
+        // The rows come in newest first, so the first row seen for a spotter is
+        // their most recent sighting.
+        const bySpotter = new Map<string, SightingsSpotter>();
         let needsUpdate = false;
 
         for (const row of rows) {
-            counts.set(row.discordUserId, (counts.get(row.discordUserId) ?? 0) + 1);
+            const spotter = bySpotter.get(row.discordUserId);
+            if (spotter) {
+                spotter.count += 1;
+            } else {
+                bySpotter.set(row.discordUserId, {
+                    discordUserId: row.discordUserId,
+                    count: 1,
+                    lastSightingAt: row.createdAt.getTime(),
+                    lastSightingUrl: this.sightingUrl(row),
+                });
+            }
 
             if (row.vehicleId === null) {
                 needsUpdate = true;
             }
         }
 
-        const spotters: SightingsSpotter[] = [];
-        for (const [spotterId, count] of counts) {
-            spotters.push({ discordUserId: spotterId, count });
-        }
+        const spotters = [...bySpotter.values()];
 
         spotters.sort(function (first: SightingsSpotter, second: SightingsSpotter): number {
             return second.count - first.count;
@@ -145,8 +146,6 @@ export class Sightings {
         return {
             total: rows.length,
             spotters,
-            lastSightingAt: newest.createdAt.getTime(),
-            lastSightingUrl: this.sightingUrl(newest),
             lastComment: newest.comment ? Str.limitCharacters(newest.comment, 100) : null,
             needsUpdate,
         };

--- a/src/services/boards.ts
+++ b/src/services/boards.ts
@@ -12,7 +12,7 @@ export class Boards {
     public static async render(view: BoardView, discordGuildId: string, user: User): Promise<ContainerBuilder[]> {
         const containers = await this.buildContainers(view, discordGuildId, user);
 
-        return BoardsView.attachTabs(containers, view);
+        return BoardsView.attachTabs(containers, view, user);
     }
 
     private static async buildContainers(

--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -6,14 +6,20 @@ export class Heartbeat {
         setInterval(this.beat.bind(this), intervalInMs);
     }
 
+    // A malformed endpoint makes get() throw synchronously; that must not take
+    // down whoever constructed the heartbeat.
     private beat(): void {
-        get(this.endpoint, (res) => {
-            const { statusCode } = res;
-            if (statusCode !== 200) {
-                console.error(`Hearbeat failed: status ${statusCode}`);
-            }
-        }).on('error', (error) => {
+        try {
+            get(this.endpoint, (res) => {
+                const { statusCode } = res;
+                if (statusCode !== 200) {
+                    console.error(`Hearbeat failed: status ${statusCode}`);
+                }
+            }).on('error', (error) => {
+                console.error(`Heartbeat failed: ${error}`);
+            });
+        } catch (error) {
             console.error(`Heartbeat failed: ${error}`);
-        });
+        }
     }
 }

--- a/src/types/license-view.types.ts
+++ b/src/types/license-view.types.ts
@@ -17,7 +17,6 @@ export interface LicenseViewData {
     badge: string | null;
     comment: string | null;
     sightings: SightingsSummary | null;
-    spotCount: number | null;
     logo: BrandLogoResult;
 }
 

--- a/src/types/sighting.types.ts
+++ b/src/types/sighting.types.ts
@@ -22,13 +22,13 @@ export interface PaginatedResult {
 export interface SightingsSpotter {
     discordUserId: string;
     count: number;
+    lastSightingAt: number;
+    lastSightingUrl: string | null;
 }
 
 export interface SightingsSummary {
     total: number;
     spotters: SightingsSpotter[];
-    lastSightingAt: number;
-    lastSightingUrl: string | null;
     lastComment: string | null;
     needsUpdate: boolean;
 }

--- a/src/util/boards-view.ts
+++ b/src/util/boards-view.ts
@@ -6,6 +6,7 @@ import {
     SeparatorBuilder,
     SeparatorSpacingSize,
     TextDisplayBuilder,
+    User,
 } from 'discord.js';
 import { BoardView } from '../types/boards.types';
 import { MostSpottedVehicle } from '../types/leaderboard.types';
@@ -23,16 +24,19 @@ export class BoardsView {
         { view: 'stats', label: 'Mijn stats', emoji: '📊' },
     ];
 
-    public static buildTabs(active: BoardView): ActionRowBuilder<ButtonBuilder> {
+    // The user id rides along in the custom id so a button press keeps showing the
+    // boards of whoever ran the command, not of the person who pressed the button.
+    public static buildTabs(active: BoardView, user: User): ActionRowBuilder<ButtonBuilder> {
         const row = new ActionRowBuilder<ButtonBuilder>();
 
         for (const tab of this.TABS) {
             const isActive = tab.view === active;
+            const label = tab.view === 'stats' ? `Stats van ${user.displayName}` : tab.label;
 
             row.addComponents(
                 new ButtonBuilder()
-                    .setCustomId(`${this.BUTTON_PREFIX}:${tab.view}`)
-                    .setLabel(tab.label)
+                    .setCustomId(`${this.BUTTON_PREFIX}:${tab.view}:${user.id}`)
+                    .setLabel(label)
                     .setEmoji(tab.emoji)
                     .setStyle(isActive ? ButtonStyle.Primary : ButtonStyle.Secondary)
                     .setDisabled(isActive)
@@ -42,12 +46,12 @@ export class BoardsView {
         return row;
     }
 
-    public static attachTabs(containers: ContainerBuilder[], active: BoardView): ContainerBuilder[] {
+    public static attachTabs(containers: ContainerBuilder[], active: BoardView, user: User): ContainerBuilder[] {
         const container = containers[containers.length - 1];
 
         if (container) {
             container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
-            container.addActionRowComponents(this.buildTabs(active));
+            container.addActionRowComponents(this.buildTabs(active, user));
         }
 
         return containers;

--- a/src/util/license-view.ts
+++ b/src/util/license-view.ts
@@ -122,10 +122,6 @@ export class LicenseView {
 
         parts.push(data.formattedLicense);
 
-        if (data.spotCount && data.spotCount > 0) {
-            parts.push(`${data.spotCount}× gespot in deze server`);
-        }
-
         return `-# ${parts.join(' · ')}`;
     }
 
@@ -276,23 +272,18 @@ export class LicenseView {
             return null;
         }
 
-        const last = DateTime.getDiscordTimestamp(sightings.lastSightingAt, DiscordTimestamps.RELATIVE);
-        const lastLink = sightings.lastSightingUrl ? `[${last}](${sightings.lastSightingUrl})` : last;
+        const lines = [`**${sightings.total}× gespot**`];
 
-        const lines = [`**${sightings.total}× gespot** — laatst ${lastLink}`];
-
-        const spotters: string[] = [];
         for (const spotter of sightings.spotters.slice(0, this.SPOTTERS_SHOWN)) {
-            spotters.push(`<@${spotter.discordUserId}> ${spotter.count}×`);
+            const spotterLast = DateTime.getDiscordTimestamp(spotter.lastSightingAt, DiscordTimestamps.RELATIVE);
+            const spotterLink = spotter.lastSightingUrl ? `[${spotterLast}](${spotter.lastSightingUrl})` : spotterLast;
+
+            lines.push(`- <@${spotter.discordUserId}> ${spotter.count}× — laatst ${spotterLink}`);
         }
 
         const remaining = sightings.spotters.length - this.SPOTTERS_SHOWN;
         if (remaining > 0) {
-            spotters.push(`en ${remaining} ${remaining === 1 ? 'ander' : 'anderen'}`);
-        }
-
-        if (spotters.length > 0) {
-            lines.push(`-# ${spotters.join(' · ')}`);
+            lines.push(`- en ${remaining} ${remaining === 1 ? 'ander' : 'anderen'}`);
         }
 
         if (sightings.lastComment) {

--- a/tests/util/boards-view.spec.ts
+++ b/tests/util/boards-view.spec.ts
@@ -1,10 +1,12 @@
-import { ButtonStyle } from 'discord.js';
+import { ButtonStyle, User } from 'discord.js';
 import { BoardsView } from '../../src/util/boards-view';
 import { MostSpottedVehicle } from '../../src/types/leaderboard.types';
 
+const user = { id: 'user-1', displayName: 'Thom' } as User;
+
 describe('BoardsView.buildTabs', () => {
-    it('renders all five tabs with leaderboard custom ids', () => {
-        const row = BoardsView.buildTabs('spotters').toJSON();
+    it('renders all five tabs with the command user in the custom ids', () => {
+        const row = BoardsView.buildTabs('spotters', user).toJSON();
 
         expect(row.components).toHaveLength(5);
 
@@ -14,16 +16,23 @@ describe('BoardsView.buildTabs', () => {
         }
 
         expect(customIds).toEqual([
-            'leaderboard:spotters',
-            'leaderboard:expensive',
-            'leaderboard:oldest',
-            'leaderboard:mostSpotted',
-            'leaderboard:stats',
+            'leaderboard:spotters:user-1',
+            'leaderboard:expensive:user-1',
+            'leaderboard:oldest:user-1',
+            'leaderboard:mostSpotted:user-1',
+            'leaderboard:stats:user-1',
         ]);
     });
 
+    it("labels the stats tab with the command user's display name", () => {
+        const row = BoardsView.buildTabs('spotters', user).toJSON();
+
+        const stats = row.components[4];
+        expect('label' in stats ? stats.label : undefined).toBe('Stats van Thom');
+    });
+
     it('marks the active tab as primary and disabled', () => {
-        const row = BoardsView.buildTabs('oldest').toJSON();
+        const row = BoardsView.buildTabs('oldest', user).toJSON();
 
         const oldest = row.components[2];
         expect(oldest.style).toBe(ButtonStyle.Primary);
@@ -71,7 +80,7 @@ describe('BoardsView.buildMostSpotted', () => {
 
 describe('BoardsView.attachTabs', () => {
     it('appends the tab row to the last container', () => {
-        const containers = BoardsView.attachTabs(BoardsView.buildMostSpotted([]), 'mostSpotted');
+        const containers = BoardsView.attachTabs(BoardsView.buildMostSpotted([]), 'mostSpotted', user);
 
         const components = containers[containers.length - 1].toJSON().components;
         const lastComponent = components[components.length - 1];

--- a/tests/util/license-view.spec.ts
+++ b/tests/util/license-view.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentType, ContainerBuilder } from 'discord.js';
 import { LicenseView } from '../../src/util/license-view';
 import { LicenseViewData } from '../../src/types/license-view.types';
-import { SightingsSummary } from '../../src/types/sighting.types';
+import { SightingsSpotter, SightingsSummary } from '../../src/types/sighting.types';
 import { VehicleInfo } from '../../src/models/vehicle-info';
 import { FuelInfo } from '../../src/models/fuel-info';
 import { EngineInfo } from '../../src/models/engine-info';
@@ -71,15 +71,20 @@ function fuelInfo(engines: Record<string, unknown>[]): FuelInfo {
     return info;
 }
 
+function spotter(discordUserId: string, count: number, overrides: Partial<SightingsSpotter> = {}): SightingsSpotter {
+    return {
+        discordUserId,
+        count,
+        lastSightingAt: NOW - 1000 * 60 * 4,
+        lastSightingUrl: null,
+        ...overrides,
+    };
+}
+
 function sightingsSummary(overrides: Partial<SightingsSummary> = {}): SightingsSummary {
     return {
         total: 8,
-        spotters: [
-            { discordUserId: 'user-1', count: 6 },
-            { discordUserId: 'user-2', count: 2 },
-        ],
-        lastSightingAt: NOW - 1000 * 60 * 4,
-        lastSightingUrl: null,
+        spotters: [spotter('user-1', 6), spotter('user-2', 2)],
         lastComment: null,
         needsUpdate: false,
         ...overrides,
@@ -95,7 +100,6 @@ function viewData(overrides: Partial<LicenseViewData> = {}): LicenseViewData {
         badge: null,
         comment: null,
         sightings: null,
-        spotCount: null,
         logo: { image: LOGO },
         ...overrides,
     };
@@ -112,9 +116,9 @@ describe('LicenseView.build', () => {
     // The brand, model and plate are drawn into the image, so they have to stay in
     // message text somewhere for Discord's search to reach them.
     it('keeps the brand, model and plate searchable in the caption', () => {
-        const contents = textContents(LicenseView.build(viewData({ spotCount: 3 }), NOW).components);
+        const contents = textContents(LicenseView.build(viewData(), NOW).components);
 
-        expect(contents).toContain('-# Opel Corsa · X-897-PL · 3× gespot in deze server');
+        expect(contents).toContain('-# Opel Corsa · X-897-PL');
     });
 
     it('names the attachment after the car so it can be found by filename', () => {
@@ -218,34 +222,35 @@ describe('LicenseView.build', () => {
         expect(textContents(LicenseView.build(data, NOW).components)).toContain('📦 Geïmporteerd');
     });
 
-    it('summarises the sightings instead of listing a row each', () => {
-        const data = viewData({ sightings: sightingsSummary() });
+    it('lists each spotter with their count and last spot', () => {
+        const data = viewData({
+            sightings: sightingsSummary({
+                spotters: [
+                    spotter('user-1', 6, { lastSightingUrl: 'https://discordapp.com/channels/1/2/3' }),
+                    spotter('user-2', 2),
+                ],
+            }),
+        });
 
         const contents = textContents(LicenseView.build(data, NOW).components);
 
-        expect(contents).toContain('**8× gespot** — laatst');
-        expect(contents).toContain('<@user-1> 6× · <@user-2> 2×');
-    });
-
-    it('links the last sighting when it can be jumped to', () => {
-        const data = viewData({
-            sightings: sightingsSummary({ lastSightingUrl: 'https://discordapp.com/channels/1/2/3' }),
-        });
-
-        expect(textContents(LicenseView.build(data, NOW).components)).toContain(
-            '](https://discordapp.com/channels/1/2/3)'
+        expect(contents).toContain('**8× gespot**');
+        expect(contents).not.toContain('**8× gespot** — laatst');
+        expect(contents).toMatch(
+            /- <@user-1> 6× — laatst \[<t:\d+:R>\]\(https:\/\/discordapp\.com\/channels\/1\/2\/3\)/
         );
+        expect(contents).toMatch(/- <@user-2> 2× — laatst <t:\d+:R>/);
     });
 
     it('counts the spotters it does not name', () => {
         const data = viewData({
             sightings: sightingsSummary({
                 spotters: [
-                    { discordUserId: 'user-1', count: 4 },
-                    { discordUserId: 'user-2', count: 3 },
-                    { discordUserId: 'user-3', count: 2 },
-                    { discordUserId: 'user-4', count: 1 },
-                    { discordUserId: 'user-5', count: 1 },
+                    spotter('user-1', 4),
+                    spotter('user-2', 3),
+                    spotter('user-3', 2),
+                    spotter('user-4', 1),
+                    spotter('user-5', 1),
                 ],
             }),
         });
@@ -254,7 +259,7 @@ describe('LicenseView.build', () => {
 
         expect(contents).toContain('<@user-3> 2×');
         expect(contents).not.toContain('<@user-4>');
-        expect(contents).toContain('en 2 anderen');
+        expect(contents).toContain('- en 2 anderen');
     });
 
     it('renders badge and comment', () => {


### PR DESCRIPTION
## What

- **/leaderboard**: pressing a tab re-rendered the boards for whoever pressed the button, so "Mijn stats" showed the presser's stats instead of the command user's. The tab custom ids now carry the invoker's user id (`leaderboard:<view>:<userId>`) and the stats tab is labelled with their display name ("Stats van …"). Buttons on messages from before this change carry no user id and keep the old behaviour.
- **/k**: the spotters are now a markdown list, one line per spotter with their count and most recent sighting as a relative timestamp, linked to the original message when it can be jumped to. The summary header loses its "— laatst …" (each line has its own) and the caption loses "N× gespot in deze server", which disagreed with the summary count because it included the spot being recorded. `Sightings.countForLicense` and `LicenseViewData.spotCount` became dead and were removed — one query fewer per /k.
- **Startup**: a malformed `heartbeatUrl` made `https.get` throw synchronously before the interaction listeners were attached, leaving a logged-in bot that answered nothing. The heartbeat now catches its own errors and starts after the listeners.

## Tests

- New coverage for the user id in the tab custom ids, the display-name label, and the per-spotter list format.
- `npx jest`: 162 passed, `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyn9AonyvuMYqmmQs8vRjF