### PR TITLE
feat: badge cars that are for sale on Marktplaats

### DIFF
--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -20,6 +20,8 @@ import { FirstSpotBadge } from '../util/first-spot-badge';
 import { LicenseView } from '../util/license-view';
 import { BrandLogo } from '../util/brand-logo';
 import { Output } from '../services/output';
+import { Marktplaats } from '../services/marktplaats';
+import { ForSale } from '../util/for-sale';
 
 interface RecordedSpot {
     vehicleId: number | null;
@@ -74,6 +76,11 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
+        // Fired here rather than inside the Promise.all below because the guard it feeds
+        // needs the brand, which the RDW has not answered with yet. Awaiting it only
+        // after the card's own data is in keeps it off the critical path.
+        const forSaleRequest = new Marktplaats().findCandidates(license);
+
         const [vehicleInfo, fuelInfo, sightings] = await Promise.all([
             VehicleInfo.get(license),
             FuelInfo.get(license),
@@ -97,12 +104,15 @@ export class License extends BaseCommand implements ICommand {
 
         const isFirstModel = await this.isFirstModel(vehicleInfo, recorded.sightingId);
 
+        const forSale = ForSale.verify(await forSaleRequest, vehicleInfo.merk);
+
         const { components, files } = LicenseView.build({
             vehicleInfo,
             fuelInfo,
             formattedLicense: LicenseUtil.format(license),
             vehicleType: LicenseUtil.getVehicleType(license),
             badge: isFirstModel ? FirstSpotBadge.message(vehicleInfo.merk, vehicleInfo.handelsbenaming) : null,
+            forSale,
             comment: this.getComment(),
             sightings,
             logo: await BrandLogo.resolve(vehicleInfo.merk),

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -76,9 +76,6 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
-        // Fired here rather than inside the Promise.all below because the guard it feeds
-        // needs the brand, which the RDW has not answered with yet. Awaiting it only
-        // after the card's own data is in keeps it off the critical path.
         const forSaleRequest = new Marktplaats().findCandidates(license);
 
         const [vehicleInfo, fuelInfo, sightings] = await Promise.all([

--- a/src/commands/license.ts
+++ b/src/commands/license.ts
@@ -76,12 +76,11 @@ export class License extends BaseCommand implements ICommand {
             return;
         }
 
-        const forSaleRequest = new Marktplaats().findCandidates(license);
-
-        const [vehicleInfo, fuelInfo, sightings] = await Promise.all([
+        const [vehicleInfo, fuelInfo, sightings, forSaleCandidates] = await Promise.all([
             VehicleInfo.get(license),
             FuelInfo.get(license),
             Sightings.summary(license, this.interaction.guildId, this.interaction.user.id),
+            new Marktplaats().findCandidates(license),
         ]);
 
         if (!vehicleInfo) {
@@ -101,7 +100,7 @@ export class License extends BaseCommand implements ICommand {
 
         const isFirstModel = await this.isFirstModel(vehicleInfo, recorded.sightingId);
 
-        const forSale = ForSale.verify(await forSaleRequest, vehicleInfo.merk);
+        const forSale = ForSale.verify(forSaleCandidates, vehicleInfo.merk);
 
         const { components, files } = LicenseView.build({
             vehicleInfo,

--- a/src/services/marktplaats.ts
+++ b/src/services/marktplaats.ts
@@ -9,7 +9,6 @@ export class Marktplaats implements MarketplaceSource {
     private static readonly TIMEOUT_MS = 2500;
     private static readonly LIMIT = 5;
 
-    // Listings are sold and withdrawn, so this cache has to expire.
     private static readonly CACHE_TTL_MS = 1000 * 60 * 30;
 
     private static readonly cache = new Map<string, { candidates: MarketplaceCandidate[]; expiresAt: number }>();
@@ -33,9 +32,6 @@ export class Marktplaats implements MarketplaceSource {
         return candidates;
     }
 
-    // Marktplaats strips the hyphens out of a search term before it matches, so
-    // `80SXS1` finds an advert spelling the plate `80-sxs-1` while `80-SXS-1` finds
-    // nothing at all.
     public static searchTerm(license: string): string {
         return license.toUpperCase().replace(/-/g, '');
     }
@@ -50,7 +46,6 @@ export class Marktplaats implements MarketplaceSource {
                     limit: Marktplaats.LIMIT,
                 },
                 headers: {
-                    // The endpoint refuses a request that does not look like the website.
                     'User-Agent':
                         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
                     Accept: 'application/json',
@@ -71,7 +66,6 @@ export class Marktplaats implements MarketplaceSource {
     }
 
     private static toCandidate(listing: MarktplaatsListing): MarketplaceCandidate {
-        // The short description is truncated, so the plate is often only in the long one.
         const descriptions = [listing.description ?? '', listing.categorySpecificDescription ?? ''];
 
         return {
@@ -95,7 +89,6 @@ export class Marktplaats implements MarketplaceSource {
         return null;
     }
 
-    // `vipUrl` is a path, not a url.
     private static absoluteUrl(vipUrl: string | undefined): string {
         if (!vipUrl) {
             return '';

--- a/src/services/marktplaats.ts
+++ b/src/services/marktplaats.ts
@@ -1,0 +1,106 @@
+import axios from 'axios';
+import { MarketplaceCandidate, MarketplaceSource } from '../types/marketplace.types';
+import { MarktplaatsListing, MarktplaatsSearchResponse } from '../types/marktplaats.types';
+
+export class Marktplaats implements MarketplaceSource {
+    public static readonly BASE_URL = 'https://www.marktplaats.nl';
+
+    private static readonly SEARCH_URL = `${Marktplaats.BASE_URL}/lrp/api/search`;
+    private static readonly TIMEOUT_MS = 2500;
+    private static readonly LIMIT = 5;
+
+    // Listings are sold and withdrawn, so this cache has to expire.
+    private static readonly CACHE_TTL_MS = 1000 * 60 * 30;
+
+    private static readonly cache = new Map<string, { candidates: MarketplaceCandidate[]; expiresAt: number }>();
+
+    public async findCandidates(license: string, now = Date.now()): Promise<MarketplaceCandidate[]> {
+        const key = Marktplaats.searchTerm(license);
+
+        const cached = Marktplaats.cache.get(key);
+        if (cached && cached.expiresAt > now) {
+            return cached.candidates;
+        }
+
+        const listings = await this.search(key);
+        const candidates: MarketplaceCandidate[] = [];
+        for (const listing of listings) {
+            candidates.push(Marktplaats.toCandidate(listing));
+        }
+
+        Marktplaats.cache.set(key, { candidates, expiresAt: now + Marktplaats.CACHE_TTL_MS });
+
+        return candidates;
+    }
+
+    // Marktplaats strips the hyphens out of a search term before it matches, so
+    // `80SXS1` finds an advert spelling the plate `80-sxs-1` while `80-SXS-1` finds
+    // nothing at all.
+    public static searchTerm(license: string): string {
+        return license.toUpperCase().replace(/-/g, '');
+    }
+
+    private async search(term: string): Promise<MarktplaatsListing[]> {
+        try {
+            const response = await axios.get<MarktplaatsSearchResponse>(Marktplaats.SEARCH_URL, {
+                timeout: Marktplaats.TIMEOUT_MS,
+                params: {
+                    query: term,
+                    searchInTitleAndDescription: true,
+                    limit: Marktplaats.LIMIT,
+                },
+                headers: {
+                    // The endpoint refuses a request that does not look like the website.
+                    'User-Agent':
+                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+                    Accept: 'application/json',
+                },
+                validateStatus: function (status: number): boolean {
+                    return status < 500;
+                },
+            });
+
+            if (response.status !== 200) {
+                return [];
+            }
+
+            return response.data?.listings ?? [];
+        } catch {
+            return [];
+        }
+    }
+
+    private static toCandidate(listing: MarktplaatsListing): MarketplaceCandidate {
+        // The short description is truncated, so the plate is often only in the long one.
+        const descriptions = [listing.description ?? '', listing.categorySpecificDescription ?? ''];
+
+        return {
+            title: listing.title ?? '',
+            description: descriptions.join(' ').trim(),
+            model: Marktplaats.attribute(listing, 'model'),
+            url: Marktplaats.absoluteUrl(listing.vipUrl),
+            priceCents: listing.priceInfo?.priceCents ?? null,
+            priceType: listing.priceInfo?.priceType ?? '',
+            reserved: listing.reserved === true,
+        };
+    }
+
+    private static attribute(listing: MarktplaatsListing, key: string): string | null {
+        for (const attribute of listing.attributes ?? []) {
+            if (attribute.key === key && attribute.value) {
+                return attribute.value;
+            }
+        }
+
+        return null;
+    }
+
+    // `vipUrl` is a path, not a url.
+    private static absoluteUrl(vipUrl: string | undefined): string {
+        if (!vipUrl) {
+            return '';
+        }
+
+        return vipUrl.startsWith('http') ? vipUrl : `${Marktplaats.BASE_URL}${vipUrl}`;
+    }
+}

--- a/src/types/hero-card.types.ts
+++ b/src/types/hero-card.types.ts
@@ -9,4 +9,5 @@ export interface HeroCardData {
     formattedLicense: string;
     logo: Buffer;
     facts: HeroCardFact[];
+    tag: string | null;
 }

--- a/src/types/license-view.types.ts
+++ b/src/types/license-view.types.ts
@@ -3,6 +3,7 @@ import { VehicleInfo } from '../models/vehicle-info';
 import { FuelInfo } from '../models/fuel-info';
 import { BrandLogoResult } from './brand-logo.types';
 import { SightingsSummary } from './sighting.types';
+import { ForSaleListing } from './marketplace.types';
 
 export interface LicenseViewMessage {
     components: ContainerBuilder[];
@@ -15,6 +16,7 @@ export interface LicenseViewData {
     formattedLicense: string;
     vehicleType: string | null;
     badge: string | null;
+    forSale: ForSaleListing | null;
     comment: string | null;
     sightings: SightingsSummary | null;
     logo: BrandLogoResult;

--- a/src/types/marketplace.types.ts
+++ b/src/types/marketplace.types.ts
@@ -1,0 +1,19 @@
+export interface ForSaleListing {
+    title: string;
+    url: string;
+    priceCents: number | null;
+}
+
+export interface MarketplaceCandidate {
+    title: string;
+    description: string;
+    model: string | null;
+    url: string;
+    priceCents: number | null;
+    priceType: string;
+    reserved: boolean;
+}
+
+export interface MarketplaceSource {
+    findCandidates(license: string): Promise<MarketplaceCandidate[]>;
+}

--- a/src/types/marktplaats.types.ts
+++ b/src/types/marktplaats.types.ts
@@ -1,0 +1,23 @@
+// Every field is optional: this is the website's own endpoint, not a documented API,
+// so it can change shape without notice.
+export interface MarktplaatsAttribute {
+    key?: string;
+    value?: string;
+}
+
+export interface MarktplaatsListing {
+    title?: string;
+    description?: string;
+    categorySpecificDescription?: string;
+    vipUrl?: string;
+    reserved?: boolean;
+    priceInfo?: {
+        priceCents?: number;
+        priceType?: string;
+    };
+    attributes?: MarktplaatsAttribute[];
+}
+
+export interface MarktplaatsSearchResponse {
+    listings?: MarktplaatsListing[];
+}

--- a/src/types/marktplaats.types.ts
+++ b/src/types/marktplaats.types.ts
@@ -1,5 +1,3 @@
-// Every field is optional: this is the website's own endpoint, not a documented API,
-// so it can change shape without notice.
 export interface MarktplaatsAttribute {
     key?: string;
     value?: string;

--- a/src/util/for-sale-badge.ts
+++ b/src/util/for-sale-badge.ts
@@ -1,0 +1,20 @@
+import { ForSaleListing } from '../types/marketplace.types';
+import { formatCurrency } from './format-currency';
+
+export class ForSaleBadge {
+    public static message(listing: ForSaleListing): string {
+        const label = listing.priceCents !== null ? formatCurrency(listing.priceCents / 100) : 'Marktplaats';
+
+        return `Deze auto staat **te koop** — [${label}](${listing.url})`;
+    }
+
+    // Drawn into the card itself, so it carries the price: the image travels on its own
+    // once it is screenshotted or forwarded, where the message text does not follow.
+    public static tag(listing: ForSaleListing): string {
+        if (listing.priceCents === null) {
+            return 'TE KOOP';
+        }
+
+        return `TE KOOP · ${formatCurrency(listing.priceCents / 100)}`;
+    }
+}

--- a/src/util/for-sale-badge.ts
+++ b/src/util/for-sale-badge.ts
@@ -8,8 +8,6 @@ export class ForSaleBadge {
         return `Deze auto staat **te koop** — [${label}](${listing.url})`;
     }
 
-    // Drawn into the card itself, so it carries the price: the image travels on its own
-    // once it is screenshotted or forwarded, where the message text does not follow.
     public static tag(listing: ForSaleListing): string {
         if (listing.priceCents === null) {
             return 'TE KOOP';

--- a/src/util/for-sale.ts
+++ b/src/util/for-sale.ts
@@ -1,10 +1,8 @@
 import { ForSaleListing, MarketplaceCandidate } from '../types/marketplace.types';
 
 export class ForSale {
-    // An allowlist, because an unrecognised price type must not be assumed to be a sale.
     private static readonly SALE_PRICE_TYPES = ['FIXED', 'MIN_BID', 'SEE_DESCRIPTION', 'NOTK', 'ON_REQUEST'];
 
-    // Parts and scrap adverts quote the plate of their donor car.
     private static readonly PARTS_MARKERS = ['onderdel', 'sloop', 'donor', 'plaatwerk', 'motorblok'];
 
     public static verify(candidates: MarketplaceCandidate[], brand: string): ForSaleListing | null {
@@ -41,8 +39,6 @@ export class ForSale {
         return this.mentionsBrand(candidate, brand);
     }
 
-    // Title only: these words turn up innocently in descriptions ("geen onderdelen
-    // vervangen"), and a false negative only costs a badge.
     private static looksLikeParts(title: string): boolean {
         const haystack = title.toLowerCase();
 
@@ -67,9 +63,6 @@ export class ForSale {
             return true;
         }
 
-        // The RDW spells a brand out in full where an advert shortens it, so
-        // "MERCEDES-BENZ" has to match "Mercedes". The length floor keeps the leading
-        // word from matching an ordinary Dutch word.
         const leading = needle.split(/[-\s]/)[0];
 
         return leading.length >= 5 && haystack.includes(leading);

--- a/src/util/for-sale.ts
+++ b/src/util/for-sale.ts
@@ -1,0 +1,77 @@
+import { ForSaleListing, MarketplaceCandidate } from '../types/marketplace.types';
+
+export class ForSale {
+    // An allowlist, because an unrecognised price type must not be assumed to be a sale.
+    private static readonly SALE_PRICE_TYPES = ['FIXED', 'MIN_BID', 'SEE_DESCRIPTION', 'NOTK', 'ON_REQUEST'];
+
+    // Parts and scrap adverts quote the plate of their donor car.
+    private static readonly PARTS_MARKERS = ['onderdel', 'sloop', 'donor', 'plaatwerk', 'motorblok'];
+
+    public static verify(candidates: MarketplaceCandidate[], brand: string): ForSaleListing | null {
+        for (const candidate of candidates) {
+            if (this.isSelling(candidate, brand)) {
+                return {
+                    title: candidate.title,
+                    url: candidate.url,
+                    priceCents: candidate.priceCents,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static isSelling(candidate: MarketplaceCandidate, brand: string): boolean {
+        if (!candidate.url) {
+            return false;
+        }
+
+        if (candidate.reserved) {
+            return false;
+        }
+
+        if (!this.SALE_PRICE_TYPES.includes(candidate.priceType)) {
+            return false;
+        }
+
+        if (this.looksLikeParts(candidate.title)) {
+            return false;
+        }
+
+        return this.mentionsBrand(candidate, brand);
+    }
+
+    // Title only: these words turn up innocently in descriptions ("geen onderdelen
+    // vervangen"), and a false negative only costs a badge.
+    private static looksLikeParts(title: string): boolean {
+        const haystack = title.toLowerCase();
+
+        for (const marker of this.PARTS_MARKERS) {
+            if (haystack.includes(marker)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static mentionsBrand(candidate: MarketplaceCandidate, brand: string): boolean {
+        const needle = brand.trim().toLowerCase();
+        if (!needle) {
+            return false;
+        }
+
+        const haystack = [candidate.title, candidate.description, candidate.model ?? ''].join(' ').toLowerCase();
+
+        if (haystack.includes(needle)) {
+            return true;
+        }
+
+        // The RDW spells a brand out in full where an advert shortens it, so
+        // "MERCEDES-BENZ" has to match "Mercedes". The length floor keeps the leading
+        // word from matching an ordinary Dutch word.
+        const leading = needle.split(/[-\s]/)[0];
+
+        return leading.length >= 5 && haystack.includes(leading);
+    }
+}

--- a/src/util/hero-card.ts
+++ b/src/util/hero-card.ts
@@ -1,5 +1,6 @@
 import { DutchPlate } from './dutch-plate';
 import { SvgRenderer } from './svg-renderer';
+import { SvgText } from './svg-text';
 import { HeroCardData, HeroCardFact } from '../types/hero-card.types';
 
 // One image carrying everything visual about the vehicle: the brand and model in
@@ -23,7 +24,6 @@ export class HeroCard {
     private static readonly PAD_TOP = 96;
     private static readonly PAD_BOTTOM = 84;
 
-    private static readonly FONT = SvgRenderer.TEXT_FONT_FAMILY;
     private static readonly CAP_HEIGHT_EM = 0.73;
 
     private static readonly EYEBROW_SIZE = 30;
@@ -41,6 +41,13 @@ export class HeroCard {
     private static readonly FACT_VALUE_SIZE = 40;
     private static readonly FACT_GAP = 56;
 
+    // A swing tag hung off the right edge of the plate: a pointed left end, a punched
+    // hole and a string back to the plate.
+    private static readonly TAG_SIZE = 34;
+    private static readonly TAG_TRACKING = 4.4;
+    private static readonly TAG_PAD_X = 34;
+    private static readonly TAG_HEIGHT = 64;
+
     private static readonly LOGO_SIZE = 700;
     private static readonly LOGO_BLEED = 90;
     private static readonly LOGO_OPACITY = 0.16;
@@ -48,6 +55,8 @@ export class HeroCard {
     private static readonly ACCENT = '#F2C500';
     private static readonly INK = '#FFFFFF';
     private static readonly INK_DIM = '#8B929F';
+    // Read against the accent fill of the tag, not against the panel.
+    private static readonly INK_INVERTED = '#12141A';
 
     public static render(data: HeroCardData): Buffer {
         const svg = [
@@ -56,6 +65,7 @@ export class HeroCard {
             `<rect width="${this.WIDTH}" height="${this.HEIGHT}" fill="url(#ground)"/>`,
             this.buildWatermark(data.logo),
             this.buildTitle(data.brand, data.model),
+            this.buildTag(data.tag),
             this.buildPlate(data.formattedLicense),
             this.buildFacts(data.facts),
             '</svg>',
@@ -106,11 +116,10 @@ export class HeroCard {
         if (eyebrow && model.trim()) {
             const baseline = this.PAD_TOP + this.EYEBROW_SIZE * this.CAP_HEIGHT_EM;
             parts.push(
-                `<text x="${this.PAD_X}" y="${baseline}" font-family="${this.FONT}" font-size="${
-                    this.EYEBROW_SIZE
-                }" font-weight="bold" letter-spacing="${this.EYEBROW_TRACKING}" fill="${
-                    this.ACCENT
-                }">${SvgRenderer.escape(eyebrow)}</text>`
+                `<text x="${this.PAD_X}" y="${baseline}" ${SvgText.bold(
+                    this.EYEBROW_SIZE,
+                    this.EYEBROW_TRACKING
+                )} fill="${this.ACCENT}">${SvgRenderer.escape(eyebrow)}</text>`
             );
         }
 
@@ -118,9 +127,9 @@ export class HeroCard {
             const fitted = this.fitHeading(heading);
             const baseline = this.MODEL_CAP_TOP + fitted.size * this.CAP_HEIGHT_EM;
             parts.push(
-                `<text x="${this.PAD_X}" y="${baseline}" font-family="${this.FONT}" font-size="${
-                    fitted.size
-                }" font-weight="bold" fill="${this.INK}">${SvgRenderer.escape(fitted.text)}</text>`
+                `<text x="${this.PAD_X}" y="${baseline}" ${SvgText.bold(fitted.size)} fill="${
+                    this.INK
+                }">${SvgRenderer.escape(fitted.text)}</text>`
             );
         }
 
@@ -150,10 +159,36 @@ export class HeroCard {
     }
 
     private static headingWidth(heading: string, size: number): number {
-        return SvgRenderer.measureTextWidth(
-            heading,
-            `font-family="${this.FONT}" font-size="${size}" font-weight="bold"`
-        );
+        return SvgText.boldWidth(heading, size);
+    }
+
+    // A filled pill in the top right corner, the one part of the canvas the title, the
+    // plate and the facts all leave empty. Drawn after the watermark so it sits on top
+    // of the logo rather than under it.
+    private static buildTag(tag: string | null): string {
+        const label = (tag ?? '').trim().toUpperCase();
+        if (!label) {
+            return '';
+        }
+
+        const attributes = SvgText.bold(this.TAG_SIZE, this.TAG_TRACKING);
+        const width = SvgText.boldWidth(label, this.TAG_SIZE, this.TAG_TRACKING) + this.TAG_PAD_X * 2;
+
+        const x = this.WIDTH - this.PAD_X - width;
+
+        // Centred on the eyebrow's cap height, so the tag and the brand read as one line.
+        const middle = this.PAD_TOP + (this.EYEBROW_SIZE * this.CAP_HEIGHT_EM) / 2;
+        const top = middle - this.TAG_HEIGHT / 2;
+        const baseline = middle + (this.TAG_SIZE * this.CAP_HEIGHT_EM) / 2;
+
+        return [
+            `<rect x="${x}" y="${top}" width="${width}" height="${this.TAG_HEIGHT}" rx="${this.TAG_HEIGHT / 2}" fill="${
+                this.ACCENT
+            }"/>`,
+            `<text x="${x + this.TAG_PAD_X}" y="${baseline}" ${attributes} fill="${
+                this.INK_INVERTED
+            }">${SvgRenderer.escape(label)}</text>`,
+        ].join('');
     }
 
     private static buildPlate(formattedLicense: string): string {
@@ -169,8 +204,8 @@ export class HeroCard {
             return '';
         }
 
-        const labelAttributes = `font-family="${this.FONT}" font-size="${this.FACT_LABEL_SIZE}" font-weight="bold" letter-spacing="${this.FACT_LABEL_TRACKING}"`;
-        const valueAttributes = `font-family="${this.FONT}" font-size="${this.FACT_VALUE_SIZE}" font-weight="bold"`;
+        const labelAttributes = SvgText.bold(this.FACT_LABEL_SIZE, this.FACT_LABEL_TRACKING);
+        const valueAttributes = SvgText.bold(this.FACT_VALUE_SIZE);
 
         const columns: { fact: HeroCardFact; label: string; width: number }[] = [];
         for (const fact of facts) {

--- a/src/util/hero-card.ts
+++ b/src/util/hero-card.ts
@@ -41,8 +41,6 @@ export class HeroCard {
     private static readonly FACT_VALUE_SIZE = 40;
     private static readonly FACT_GAP = 56;
 
-    // A swing tag hung off the right edge of the plate: a pointed left end, a punched
-    // hole and a string back to the plate.
     private static readonly TAG_SIZE = 34;
     private static readonly TAG_TRACKING = 4.4;
     private static readonly TAG_PAD_X = 34;
@@ -55,7 +53,6 @@ export class HeroCard {
     private static readonly ACCENT = '#F2C500';
     private static readonly INK = '#FFFFFF';
     private static readonly INK_DIM = '#8B929F';
-    // Read against the accent fill of the tag, not against the panel.
     private static readonly INK_INVERTED = '#12141A';
 
     public static render(data: HeroCardData): Buffer {
@@ -162,9 +159,6 @@ export class HeroCard {
         return SvgText.boldWidth(heading, size);
     }
 
-    // A filled pill in the top right corner, the one part of the canvas the title, the
-    // plate and the facts all leave empty. Drawn after the watermark so it sits on top
-    // of the logo rather than under it.
     private static buildTag(tag: string | null): string {
         const label = (tag ?? '').trim().toUpperCase();
         if (!label) {
@@ -176,7 +170,6 @@ export class HeroCard {
 
         const x = this.WIDTH - this.PAD_X - width;
 
-        // Centred on the eyebrow's cap height, so the tag and the brand read as one line.
         const middle = this.PAD_TOP + (this.EYEBROW_SIZE * this.CAP_HEIGHT_EM) / 2;
         const top = middle - this.TAG_HEIGHT / 2;
         const baseline = middle + (this.TAG_SIZE * this.CAP_HEIGHT_EM) / 2;

--- a/src/util/license-view.ts
+++ b/src/util/license-view.ts
@@ -22,6 +22,7 @@ import { SightingsSummary } from '../types/sighting.types';
 import { Str } from './str';
 import { DateTime } from './date-time';
 import { formatCurrency } from './format-currency';
+import { ForSaleBadge } from './for-sale-badge';
 import { DiscordTimestamps } from '../enums/discord-timestamps';
 
 export class LicenseView {
@@ -49,6 +50,9 @@ export class LicenseView {
         }
 
         const notes: string[] = [];
+        if (data.forSale) {
+            notes.push(`🏷️ ${ForSaleBadge.message(data.forSale)}`);
+        }
         if (data.badge) {
             notes.push(`🥇 ${data.badge}`);
         }
@@ -77,6 +81,7 @@ export class LicenseView {
             formattedLicense: data.formattedLicense,
             logo: data.logo.image,
             facts: this.buildFacts(data, now),
+            tag: data.forSale ? ForSaleBadge.tag(data.forSale) : null,
         });
 
         return { components: [container], files: [new AttachmentBuilder(hero, { name: fileName })] };

--- a/src/util/svg-text.ts
+++ b/src/util/svg-text.ts
@@ -1,0 +1,21 @@
+import { SvgRenderer } from './svg-renderer';
+
+export class SvgText {
+    public static bold(size: number, tracking: number | null = null): string {
+        const attributes = [
+            `font-family="${SvgRenderer.TEXT_FONT_FAMILY}"`,
+            `font-size="${size}"`,
+            'font-weight="bold"',
+        ];
+
+        if (tracking !== null) {
+            attributes.push(`letter-spacing="${tracking}"`);
+        }
+
+        return attributes.join(' ');
+    }
+
+    public static boldWidth(text: string, size: number, tracking: number | null = null): number {
+        return SvgRenderer.measureTextWidth(text, this.bold(size, tracking));
+    }
+}

--- a/tests/services/marktplaats.spec.ts
+++ b/tests/services/marktplaats.spec.ts
@@ -1,0 +1,153 @@
+import axios from 'axios';
+import { Marktplaats } from '../../src/services/marktplaats';
+import { MarktplaatsListing } from '../../src/types/marktplaats.types';
+
+jest.mock('axios');
+
+const mockedGet = axios.get as jest.MockedFunction<typeof axios.get>;
+
+const SEARCH_URL = 'https://www.marktplaats.nl/lrp/api/search';
+const CACHE_TTL_MS = 1000 * 60 * 30;
+
+function listing(overrides: Partial<MarktplaatsListing> = {}): MarktplaatsListing {
+    return {
+        title: 'Ford Ka 1.2 69pk 2012 Wit',
+        description: 'Nette ford ka 1.2 (kenteken: 12-abc-3).',
+        categorySpecificDescription: 'Nette ford ka 1.2 (kenteken: 12-abc-3). Deze auto is van mijn moeder geweest.',
+        vipUrl: '/v/auto-s/ford/m0000000001-ford-ka-1-2-69pk-2012-wit',
+        reserved: false,
+        priceInfo: { priceCents: 290000, priceType: 'FIXED' },
+        attributes: [
+            { key: 'constructionYear', value: '2012' },
+            { key: 'model', value: 'Ka' },
+        ],
+        ...overrides,
+    };
+}
+
+function response(status: number, listings: MarktplaatsListing[] = []) {
+    return { status, data: { listings } };
+}
+
+describe('Marktplaats.searchTerm', () => {
+    it('strips the hyphens a plate is written with', () => {
+        expect(Marktplaats.searchTerm('12-abc-3')).toBe('12ABC3');
+    });
+});
+
+describe('Marktplaats.findCandidates', () => {
+    beforeEach(() => {
+        mockedGet.mockReset();
+    });
+
+    // The hyphenated term matches nothing at all on Marktplaats, so this is the one
+    // detail the whole lookup rests on.
+    it('searches for the plate without its hyphens', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing()]));
+
+        await new Marktplaats().findCandidates('12-ABC-3');
+
+        expect(mockedGet).toHaveBeenCalledWith(
+            SEARCH_URL,
+            expect.objectContaining({
+                params: expect.objectContaining({ query: '12ABC3', searchInTitleAndDescription: true }),
+            })
+        );
+    });
+
+    it('maps a listing onto a candidate', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing()]));
+
+        const candidates = await new Marktplaats().findCandidates('11AAA1');
+
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0]).toEqual({
+            title: 'Ford Ka 1.2 69pk 2012 Wit',
+            description: expect.stringContaining('Deze auto is van mijn moeder geweest.'),
+            model: 'Ka',
+            url: 'https://www.marktplaats.nl/v/auto-s/ford/m0000000001-ford-ka-1-2-69pk-2012-wit',
+            priceCents: 290000,
+            priceType: 'FIXED',
+            reserved: false,
+        });
+    });
+
+    it('keeps the plate from the truncated description as well as the long one', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing()]));
+
+        const candidates = await new Marktplaats().findCandidates('22BBB2');
+
+        expect(candidates[0].description).toContain('kenteken: 12-abc-3');
+    });
+
+    it('leaves an absolute vipUrl alone', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing({ vipUrl: 'https://www.marktplaats.nl/v/elders' })]));
+
+        const candidates = await new Marktplaats().findCandidates('33CCC3');
+
+        expect(candidates[0].url).toBe('https://www.marktplaats.nl/v/elders');
+    });
+
+    it('copes with a listing that is missing every optional field', async () => {
+        mockedGet.mockResolvedValue(response(200, [{}]));
+
+        const candidates = await new Marktplaats().findCandidates('44DDD4');
+
+        expect(candidates[0]).toEqual({
+            title: '',
+            description: '',
+            model: null,
+            url: '',
+            priceCents: null,
+            priceType: '',
+            reserved: false,
+        });
+    });
+
+    it('returns nothing when no advert mentions the plate', async () => {
+        mockedGet.mockResolvedValue(response(200, []));
+
+        expect(await new Marktplaats().findCandidates('55EEE5')).toEqual([]);
+    });
+
+    it('returns nothing when the endpoint answers with an error status', async () => {
+        mockedGet.mockResolvedValue(response(404));
+
+        expect(await new Marktplaats().findCandidates('66FFF6')).toEqual([]);
+    });
+
+    it('returns nothing when the request fails', async () => {
+        mockedGet.mockRejectedValue(new Error('timeout'));
+
+        expect(await new Marktplaats().findCandidates('77GGG7')).toEqual([]);
+    });
+
+    it('caches per plate', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing()]));
+
+        await new Marktplaats().findCandidates('88HHH8');
+        await new Marktplaats().findCandidates('88HHH8');
+
+        expect(mockedGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a miss too, so an ordinary plate is only looked up once', async () => {
+        mockedGet.mockResolvedValue(response(200, []));
+
+        await new Marktplaats().findCandidates('99JJJ9');
+        await new Marktplaats().findCandidates('99JJJ9');
+
+        expect(mockedGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('looks the plate up again once the cached answer has expired', async () => {
+        mockedGet.mockResolvedValue(response(200, [listing()]));
+
+        // The only test that needs a clock at all, so it gets the two instants it
+        // needs rather than a date: the cache is filled, then read back too late.
+        await new Marktplaats().findCandidates('10KKK1', 0);
+        await new Marktplaats().findCandidates('10KKK1', CACHE_TTL_MS + 1);
+
+        expect(mockedGet).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/util/for-sale-badge.spec.ts
+++ b/tests/util/for-sale-badge.spec.ts
@@ -1,0 +1,34 @@
+import { ForSaleBadge } from '../../src/util/for-sale-badge';
+import { formatCurrency } from '../../src/util/format-currency';
+
+const URL = 'https://www.marktplaats.nl/v/auto-s/ford/m1-ford-ka';
+
+describe('ForSaleBadge.message', () => {
+    it('links the price to the advert', () => {
+        const message = ForSaleBadge.message({ title: 'Ford Ka', url: URL, priceCents: 290000 });
+
+        expect(message).toBe(`Deze auto staat **te koop** — [${formatCurrency(2900)}](${URL})`);
+    });
+
+    it('names the marketplace when the advert has no price', () => {
+        const message = ForSaleBadge.message({ title: 'Ford Ka', url: URL, priceCents: null });
+
+        expect(message).toBe(`Deze auto staat **te koop** — [Marktplaats](${URL})`);
+    });
+
+    it('puts the price in the tag drawn into the card', () => {
+        const tag = ForSaleBadge.tag({ title: 'Ford Ka', url: URL, priceCents: 290000 });
+
+        expect(tag).toBe(`TE KOOP · ${formatCurrency(2900)}`);
+    });
+
+    it('falls back to a bare tag when the advert has no price', () => {
+        expect(ForSaleBadge.tag({ title: 'Ford Ka', url: URL, priceCents: null })).toBe('TE KOOP');
+    });
+
+    it('rounds a price given in cents down to whole euros', () => {
+        const message = ForSaleBadge.message({ title: 'Ford Ka', url: URL, priceCents: 295050 });
+
+        expect(message).toContain(formatCurrency(2950.5));
+    });
+});

--- a/tests/util/for-sale.spec.ts
+++ b/tests/util/for-sale.spec.ts
@@ -1,0 +1,118 @@
+import { ForSale } from '../../src/util/for-sale';
+import { MarketplaceCandidate } from '../../src/types/marketplace.types';
+
+function candidate(overrides: Partial<MarketplaceCandidate> = {}): MarketplaceCandidate {
+    return {
+        title: 'Ford Ka 1.2 69pk 2012 Wit',
+        description: 'Nette ford ka 1.2 (kenteken: 12-abc-3).',
+        model: 'Ka',
+        url: 'https://www.marktplaats.nl/v/auto-s/ford/m1-ford-ka',
+        priceCents: 290000,
+        priceType: 'FIXED',
+        reserved: false,
+        ...overrides,
+    };
+}
+
+describe('ForSale.verify', () => {
+    it('accepts an advert for the same brand', () => {
+        expect(ForSale.verify([candidate()], 'FORD')).toEqual({
+            title: 'Ford Ka 1.2 69pk 2012 Wit',
+            url: 'https://www.marktplaats.nl/v/auto-s/ford/m1-ford-ka',
+            priceCents: 290000,
+        });
+    });
+
+    it('accepts a brand the advert shortened', () => {
+        const shortened = candidate({
+            title: 'Mercedes C200 AMG-line',
+            description: 'kenteken 12-abc-3',
+            model: 'C-Klasse',
+        });
+
+        expect(ForSale.verify([shortened], 'MERCEDES-BENZ')).not.toBeNull();
+    });
+
+    it('accepts a brand that only appears in the description', () => {
+        const buried = candidate({ title: 'Nette gezinsauto met nieuwe APK', model: null });
+
+        expect(ForSale.verify([buried], 'FORD')).not.toBeNull();
+    });
+
+    it('rejects an advert for another car that happens to quote the plate', () => {
+        expect(ForSale.verify([candidate()], 'OPEL')).toBeNull();
+    });
+
+    it('rejects a parts advert quoting its donor car', () => {
+        const parts = candidate({ title: 'Ford Ka onderdelen, alles moet weg' });
+
+        expect(ForSale.verify([parts], 'FORD')).toBeNull();
+    });
+
+    it('rejects a scrap advert', () => {
+        const scrap = candidate({ title: 'Sloopauto Ford Ka 2012' });
+
+        expect(ForSale.verify([scrap], 'FORD')).toBeNull();
+    });
+
+    it('still accepts an advert that only mentions parts in its description', () => {
+        const honest = candidate({ description: 'Ford ka, geen onderdelen vervangen, kenteken 12-abc-3' });
+
+        expect(ForSale.verify([honest], 'FORD')).not.toBeNull();
+    });
+
+    it('rejects a reserved advert', () => {
+        expect(ForSale.verify([candidate({ reserved: true })], 'FORD')).toBeNull();
+    });
+
+    it('rejects a lease advert, which is not the car being sold', () => {
+        expect(ForSale.verify([candidate({ priceType: 'LEASE' })], 'FORD')).toBeNull();
+    });
+
+    it('rejects an unrecognised price type rather than assuming a sale', () => {
+        expect(ForSale.verify([candidate({ priceType: 'EXCHANGE' })], 'FORD')).toBeNull();
+    });
+
+    it('accepts an advert without a price', () => {
+        const noPrice = candidate({ priceCents: null, priceType: 'NOTK' });
+
+        expect(ForSale.verify([noPrice], 'FORD')?.priceCents).toBeNull();
+    });
+
+    it('rejects a listing it cannot link to', () => {
+        expect(ForSale.verify([candidate({ url: '' })], 'FORD')).toBeNull();
+    });
+
+    it('does not match a short leading brand word against ordinary Dutch', () => {
+        const unrelated = candidate({
+            title: 'Volkswagen Golf in landelijke omgeving',
+            description: 'kenteken 12-abc-3',
+            model: 'Golf',
+        });
+
+        expect(ForSale.verify([unrelated], 'LAND ROVER')).toBeNull();
+    });
+
+    it('still matches a full multi-word brand', () => {
+        const defender = candidate({ title: 'Land Rover Defender 110', model: 'Defender' });
+
+        expect(ForSale.verify([defender], 'LAND ROVER')).not.toBeNull();
+    });
+
+    it('returns the first advert that survives the guard', () => {
+        const rejected = candidate({ title: 'Ford Ka onderdelen' });
+        const accepted = candidate({ url: 'https://www.marktplaats.nl/v/auto-s/ford/m2-ford-ka' });
+
+        expect(ForSale.verify([rejected, accepted], 'FORD')?.url).toBe(
+            'https://www.marktplaats.nl/v/auto-s/ford/m2-ford-ka'
+        );
+    });
+
+    it('returns nothing when no advert mentions the plate', () => {
+        expect(ForSale.verify([], 'FORD')).toBeNull();
+    });
+
+    it('returns nothing when the brand is unknown', () => {
+        expect(ForSale.verify([candidate()], '')).toBeNull();
+    });
+});

--- a/tests/util/hero-card.spec.ts
+++ b/tests/util/hero-card.spec.ts
@@ -19,6 +19,7 @@ function cardData(overrides: Partial<HeroCardData> = {}): HeroCardData {
             { label: 'Vermogen', value: '95 pk' },
             { label: 'Bouwjaar', value: '2020' },
         ],
+        tag: null,
         ...overrides,
     };
 }
@@ -54,6 +55,27 @@ describe('HeroCard.render', () => {
         const card = HeroCard.render(cardData({ brand: '', model: '', facts: [] }));
 
         expect(card.subarray(0, 8)).toEqual(PNG_MAGIC);
+    });
+
+    it('draws the tag without changing the canvas', () => {
+        const plain = HeroCard.render(cardData());
+        const tagged = HeroCard.render(cardData({ tag: 'TE KOOP · € 8.750' }));
+
+        expect(dimensions(tagged)).toEqual(dimensions(plain));
+        expect(tagged.length).toBeGreaterThan(plain.length);
+    });
+
+    it('leaves the card untouched when the tag is blank', () => {
+        const plain = HeroCard.render(cardData());
+
+        expect(HeroCard.render(cardData({ tag: '   ' }))).toEqual(plain);
+    });
+
+    it('widens the tag to fit a longer label', () => {
+        const short = HeroCard.render(cardData({ tag: 'TE KOOP' })).length;
+        const long = HeroCard.render(cardData({ tag: 'TE KOOP · € 129.950' })).length;
+
+        expect(long).toBeGreaterThan(short);
     });
 
     it('draws more ink for a longer model name', () => {

--- a/tests/util/license-view.spec.ts
+++ b/tests/util/license-view.spec.ts
@@ -98,6 +98,7 @@ function viewData(overrides: Partial<LicenseViewData> = {}): LicenseViewData {
         formattedLicense: 'X-897-PL',
         vehicleType: null,
         badge: null,
+        forSale: null,
         comment: null,
         sightings: null,
         logo: { image: LOGO },
@@ -269,6 +270,23 @@ describe('LicenseView.build', () => {
 
         expect(contents).toContain('🥇 Je bent de eerste!');
         expect(contents).toContain('💬 _mooie kar_');
+    });
+
+    it('renders the for-sale note above the first-spot badge', () => {
+        const data = viewData({
+            badge: 'Je bent de eerste!',
+            forSale: {
+                title: 'Ford Ka 1.2 69pk 2012 Wit',
+                url: 'https://www.marktplaats.nl/v/auto-s/ford/m1-ford-ka',
+                priceCents: 290000,
+            },
+        });
+
+        const contents = textContents(LicenseView.build(data, NOW).components);
+
+        expect(contents).toContain('🏷️ Deze auto staat **te koop**');
+        expect(contents).toContain('(https://www.marktplaats.nl/v/auto-s/ford/m1-ford-ka)');
+        expect(contents.indexOf('🏷️')).toBeLessThan(contents.indexOf('🥇'));
     });
 
     it('uses an accent colour based on the primary fuel type', () => {


### PR DESCRIPTION
Shows a 🏷️ badge on `/k` when the spotted car is currently advertised for sale on Marktplaats, with the asking price both in the reply and drawn onto the hero card.

## Why it only does exact plate matches

I went looking for a way to ask "is this car for sale" and mostly found out that you cannot:

| Route | Finding |
|---|---|
| Marktplaats official API | Has a search endpoint, but registration is manual with "no automated procedure". Unobtainable. |
| Marktplaats site JSON (`/lrp/api/search`) | Works unauthenticated. Returns title, description, price, attributes, `vipUrl`. |
| AutoScout24 official API | Write-only listing creation for registered dealers. No search or read endpoint exists at all. |
| RDW open data | All 99 columns of `m9d7-ebf2` checked — no `bedrijfsvoorraad` / dealer-stock / for-sale signal. |

**No marketplace exposes the kenteken.** Listing `attributes` and `extendedAttributes` have no plate field, and it is not a search filter either. The only exact signal left is sellers who type the plate into the advert text, which *is* searchable.

So this matches on the plate and never guesses. That costs recall: roughly **4%** of car adverts print their plate (1 of 25 sampled), so the badge will fire on something like **1 in 500 spots**. That is the deliberate trade-off — a rare badge that is right beats a common one that is wrong. The alternative, matching on brand/model/year, finds hundreds of other cars and cannot tell you about *this* one.

## The one detail everything rests on

Marktplaats normalises a search term before matching, so the plate has to be sent **without** its hyphens:

- `query=80-SXS-1` → **0 results**
- `query=80SXS1` → **1 result**, the advert whose description reads `kenteken: 80-sxs-1`

`license.ts` already produces that form. There is a test asserting the outgoing `query` param has no hyphens, because this silently returns nothing if it regresses.

## Design

- `Marktplaats` fetches candidates; the pure `ForSale.verify` guards them. Splitting the two keeps the guard testable without axios.
- The guard rejects reserved adverts, non-sale price types (an allowlist, so an unknown type is never assumed to be a sale), parts/scrap adverts quoting a donor car, and anything whose brand does not match the RDW's.
- The lookup fires *before* the RDW reads and is awaited after them, so it stays off the critical path even though the guard needs the brand.
- Defensive HTTP modelled on `brand-logo.ts`: 2.5s timeout, `validateStatus`, everything swallowed. **Every failure path degrades to no badge.**
- Cache keyed by plate with a 30 minute TTL, caching misses too. Deliberately unlike `BrandLogo`'s TTL-less cache — logos are immutable, listings sell.
- `SvgText` collects the bold-text attribute builder `hero-card` repeated six times.

No API key, so `settings.json.example`, `AvailableSettings` and the deploy workflow are untouched. No migration — the lookup is live and never persisted.

## Risk worth knowing

`lrp/api/search` is the website's own endpoint, not a sanctioned API. One request per `/k` is low volume and circumvents no auth or bot protection, but it is outside Marktplaats' terms and could be blocked or reshaped without notice. Because every failure degrades to "no badge", a block would be **silent**.

## Verification

202 tests pass, typecheck and lint clean. Verified end-to-end against live adverts: correct plate + correct brand produces the badge with a working link; the same plate with the wrong brand is rejected by the guard; a control plate returns nothing. Of 100 adverts mentioning "kenteken", all 23 that contained a valid plate resolved in the RDW and passed the guard — no false positives to chase.

Test fixtures use a synthetic plate so nothing in `tests/` depends on a live advert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
