### PR TITLE
fix: trim trade name after stripping the brand

### DIFF
--- a/database/migrations/20260806120000-trim-vehicle-trade-names.js
+++ b/database/migrations/20260806120000-trim-vehicle-trade-names.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// VehicleInfo stripped the brand out of the RDW trade name with a plain replace,
+// so "VOLKSWAGEN GOLF" was stored as " GOLF". Every tradeName written before that
+// replace started trimming carries the separating space, which the hero card and
+// the first-spot badge render verbatim.
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface) {
+        await queryInterface.sequelize.query(
+            `UPDATE Vehicles
+             SET tradeName = TRIM(tradeName)
+             WHERE tradeName IS NOT NULL
+               AND tradeName <> TRIM(tradeName)`
+        );
+    },
+
+    // Deliberately empty: the stripped whitespace is not recorded anywhere, and
+    // re-adding a leading space would be restoring the bug rather than the data.
+    async down() {},
+};

--- a/src/models/vehicle-info.ts
+++ b/src/models/vehicle-info.ts
@@ -47,7 +47,7 @@ export class VehicleInfo extends BaseModel {
         super();
         this.hydrate(data);
 
-        this.handelsbenaming = this.handelsbenaming.replace(this.merk, '');
+        this.handelsbenaming = this.handelsbenaming.replace(this.merk, '').trim();
     }
 
     public static async get(license: string): Promise<VehicleInfo | null> {

--- a/src/util/license-view.ts
+++ b/src/util/license-view.ts
@@ -135,7 +135,7 @@ export class LicenseView {
     }
 
     private static modelName(data: LicenseViewData): string {
-        const model = data.vehicleInfo.handelsbenaming.trim();
+        const model = data.vehicleInfo.handelsbenaming;
 
         return model ? Str.toTitleCase(model) : '';
     }


### PR DESCRIPTION
## What

`VehicleInfo` strips the brand out of the RDW trade name so the two are not repeated next to each other, but it did so with a plain `replace`. RDW returns `merk: "VOLKSWAGEN"` and `handelsbenaming: "VOLKSWAGEN GOLF"`, so what was left behind was `" GOLF"` — brand gone, separating space still there.

`LicenseView.modelName` happened to `.trim()` on its own, which is why the embed looked fine. The paths that did not trim were carrying the space:

- `Vehicles.tradeName` — persisted with the leading space
- the hero card title
- the first-spot badge

## Changes

- **`src/models/vehicle-info.ts`** — trim after the replace, fixing it at the source for every consumer.
- **`src/util/license-view.ts`** — drop the now-redundant view-level trim.
- **`database/migrations/20260806120000-trim-vehicle-trade-names.js`** — `TRIM` the rows written before the fix. `down()` is deliberately empty, matching the convention in the sighting-vehicle-ids backfill: the stripped whitespace is not recorded anywhere, and re-adding a leading space would be restoring the bug rather than the data.

## Testing

- 202 tests pass, `tsc --noEmit` clean.
- Migration exercised on a throwaway SQLite db first: `' GOLF'` → `'GOLF'`, `' A-KLASSE '` → `'A-KLASSE'`, with `'CORSA'`, `NULL` and `''` untouched.
- Ran against the local db (6 rows with a `tradeName`, none left untrimmed) and started the bot to confirm lookups render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)