### PR TITLE
fix: trim leftover space when stripping duplicate brand from trade name

### DIFF
--- a/src/models/vehicle-info.ts
+++ b/src/models/vehicle-info.ts
@@ -47,7 +47,7 @@ export class VehicleInfo extends BaseModel {
         super();
         this.hydrate(data);
 
-        this.handelsbenaming = this.handelsbenaming.replace(this.merk, '');
+        this.handelsbenaming = this.handelsbenaming.replace(this.merk, '').trim();
     }
 
     public static async get(license: string): Promise<VehicleInfo | null> {

--- a/tests/models/vehicle-info.spec.ts
+++ b/tests/models/vehicle-info.spec.ts
@@ -1,0 +1,15 @@
+import { VehicleInfo } from '../../src/models/vehicle-info';
+
+describe('VehicleInfo model', () => {
+    it('should strip the duplicated brand from the trade name without leaving a leading space', () => {
+        const vehicle = new VehicleInfo({ merk: 'NISSAN', handelsbenaming: 'NISSAN 350Z' });
+
+        expect(vehicle.handelsbenaming).toBe('350Z');
+    });
+
+    it('should keep a trade name that does not repeat the brand', () => {
+        const vehicle = new VehicleInfo({ merk: 'NISSAN', handelsbenaming: '350Z' });
+
+        expect(vehicle.handelsbenaming).toBe('350Z');
+    });
+});


### PR DESCRIPTION
## What

When a vehicle's trade name (`handelsbenaming`) repeats the brand (`merk`) — e.g. brand `NISSAN`, trade name `NISSAN 350Z` — the `VehicleInfo` constructor strips the brand out of the trade name so it isn't shown twice. But `replace(this.merk, '')` removes only the substring and leaves the surrounding whitespace, so `"NISSAN 350Z"` becomes `" 350Z"`.

Every display site concatenates `` `${brand} ${tradeName}` ``, so the leftover leading space produced a double space: `"Nissan  350Z"`.

## Fix

Add `.trim()` after the `replace(...)` in `src/models/vehicle-info.ts`. This is the single source point, so every display site (boards, leaderboard, stats, superlatives, search, sightings, spot-suggestion, license) is fixed at once.

## Tests

Added `tests/models/vehicle-info.spec.ts` asserting the duplicated brand is stripped without a leading space, and that a non-repeating trade name is left untouched. Full suite (166 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)