### PR TITLE
ci: update the GitHub Actions and add a Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
@@ -40,7 +40,7 @@ jobs:
         run: zip release.zip . -ry
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bot
           path: ./release.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bot
 
@@ -32,7 +32,7 @@ jobs:
           sed -i 's/HEARTBEAT_URL/${{ secrets.HEARTBEAT_URL }}/g' settings.json  
 
       - name: Deploy
-        uses: burnett01/rsync-deployments@7.1.0
+        uses: burnett01/rsync-deployments@v9
         with:
           switches: -avzr --delete --exclude kentekenbot.db
           remote_path: ${{ secrets.DEPLOY_PATH }}
@@ -41,7 +41,7 @@ jobs:
           remote_key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Post deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -10,10 +10,10 @@ jobs:
     name: Test and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
The v4 deploy run flagged every `actions/*` step as targeting the deprecated Node 20 runtime, forced onto Node 24 by the runner. This brings them up to date and adds a Dependabot config so they stop drifting.

## Action versions

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `burnett01/rsync-deployments` | 7.1.0 | v9 |
| `appleboy/ssh-action` | `master` | v1.2.5 |

`appleboy/ssh-action` was tracking a moving branch while holding the deploy SSH key, so any push to that repository's default branch reached production. It is now on a fixed tag.

I checked `action.yml` on the new tags for both third-party actions, since they run in the deploy path. rsync v9 still takes `switches`, `remote_path`, `remote_host`, `remote_user` and `remote_key`; ssh-action v1.2.5 still takes `host`, `username`, `key` and `script`. No input renames, so the `with:` blocks are untouched.

## Dependabot

There was no config in the repository at all, which means only security updates were running — that is why the open npm PRs are all advisory bumps. This adds `github-actions` on a weekly schedule, grouped into one pull request rather than six, and prefixed `ci(deps):` to match the commit convention.

Scoped to `github-actions` deliberately. Adding `npm` would switch on version updates for every dependency, which is a much larger change than this PR is for.

## Testing

This PR exercises `test-and-lint.yml`, so checkout v7 and cache v6 are covered by its own CI run.

It does **not** cover `deploy.yml`, which only runs on a tag push. The rsync and ssh-action bumps stay unproven until the next release tag, and that goes straight through to Production without a gate. Worth a look at the Testing job on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
